### PR TITLE
Investigate Windows SIGINT handling issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,13 @@ jobs:
         pip install pandas
         pip install pytest pytest-cov
 
-    - name: Run tests
+    - name: Run tests (Windows - interrupt focus)
+      if: runner.os == 'Windows'
+      run: |
+        pytest tests/test_interrupt_handling.py -v --tb=long -s
+
+    - name: Run tests (Non-Windows)
+      if: runner.os != 'Windows'
       run: |
         pytest tests/ -v --tb=short -x --ignore=tests/test_examples_advanced.py --ignore=tests/test_examples_modelica.py --ignore=tests/test_examples_perfectgaz.py --ignore=tests/test_examples_runner.py --ignore=tests/test_examples_telemac.py
 


### PR DESCRIPTION
## Purpose
Investigation branch to isolate and diagnose Windows CI failures related to interrupt handling.

## Changes
- **Windows CI**: Run only `test_interrupt_handling.py` with verbose output (`-v --tb=long -s`)
- **Other platforms**: Continue running full test suite as normal

## Background
The CI run https://github.com/Funz/fz/actions/runs/18230502367 showed failures across all Windows Python versions. This PR isolates the interrupt handling tests to determine if SIGINT-related issues are the root cause.

Windows handles signals differently than Unix systems (uses `signal.CTRL_C_EVENT` instead of `SIGINT`), which may cause test failures or timeouts.

## Expected Outcomes
This will help us understand:
1. Whether interrupt tests pass/fail on Windows
2. If there are timing issues specific to Windows
3. Any Windows-specific signal handling problems
4. Whether other tests were failing due to interrupt test side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)