### PR TITLE
Refactor var_values to input_variables throughout codebase

### DIFF
--- a/.github/workflows/README.yml
+++ b/.github/workflows/README.yml
@@ -140,7 +140,7 @@ jobs:
         }
 
         # Define parameter values
-        var_values = {
+        input_variables = {
             "T_celsius": [10, 20],  # 2 temperatures (reduced for quick test)
             "V_L": [1, 2],           # 2 volumes (reduced for quick test)
             "n_mol": 1.0             # fixed amount
@@ -150,7 +150,7 @@ jobs:
         results = fz.fzr(
             "input.txt",
             model,
-            var_values,
+            input_variables,
             calculators="sh://bash PerfectGazPressure.sh",
             results_dir="results"
         )
@@ -245,7 +245,7 @@ jobs:
                 "commentline": "#"
             }
 
-            var_values = {
+            input_variables = {
                 "T_celsius": 25,
                 "V_L": 10,
                 "n_mol": 2
@@ -255,7 +255,7 @@ jobs:
             fz.fzc(
                 str(input_file),
                 model,
-                var_values,
+                input_variables,
                 engine="python",
                 output_dir=str(output_dir)
             )

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ model = {
 }
 
 # Define parameter values
-var_values = {
+input_variables = {
     "T_celsius": [10, 20, 30, 40],  # 4 temperatures
     "V_L": [1, 2, 5],                # 3 volumes
     "n_mol": 1.0                     # fixed amount
@@ -131,7 +131,7 @@ var_values = {
 results = fz.fzr(
     "input.txt",
     model,
-    var_values,
+    input_variables,
     calculators="sh://bash PerfectGazPressure.sh",
     results_dir="results"
 )
@@ -196,7 +196,7 @@ model = {
     "commentline": "#"
 }
 
-var_values = {
+input_variables = {
     "T_celsius": 25,
     "V_L": 10,
     "n_mol": 2
@@ -206,7 +206,7 @@ var_values = {
 fz.fzc(
     "input.txt",
     model,
-    var_values,
+    input_variables,
     engine="python",
     output_dir="compiled"
 )
@@ -228,7 +228,7 @@ fz.fzc(
 **Parameters**:
 - `input_path`: Path to input file or directory
 - `model`: Model definition (dict or alias name)
-- `var_values`: Dictionary of variable values (scalar or list)
+- `input_variables`: Dictionary of variable values (scalar or list)
 - `engine`: Expression evaluator (`"python"` or `"R"`, default: `"python"`)
 - `output_dir`: Output directory path
 
@@ -289,7 +289,7 @@ model = {
 results = fz.fzr(
     input_path="input.txt",
     model=model,
-    var_values={
+    input_variables={
         "temperature": [100, 200, 300],
         "pressure": [1, 10, 100],
         "concentration": 0.5
@@ -309,7 +309,7 @@ print(results)
 **Parameters**:
 - `input_path`: Input file or directory path
 - `model`: Model definition (dict or alias)
-- `var_values`: Variable values (creates Cartesian product of lists)
+- `input_variables`: Variable values (creates Cartesian product of lists)
 - `engine`: Expression evaluator (default: `"python"`)
 - `calculators`: Calculator URI(s) - string or list
 - `results_dir`: Results directory path
@@ -360,7 +360,7 @@ Store reusable models in `.fz/models/`:
 
 Use by name:
 ```python
-results = fz.fzr("input.txt", "perfectgas", var_values)
+results = fz.fzr("input.txt", "perfectgas", input_variables)
 ```
 
 ### Formula Evaluation
@@ -486,7 +486,7 @@ Store calculator configurations in `.fz/calculators/`:
 
 Use by name:
 ```python
-results = fz.fzr("input.txt", "perfectgas", var_values, calculators="cluster")
+results = fz.fzr("input.txt", "perfectgas", input_variables, calculators="cluster")
 ```
 
 ## Advanced Features
@@ -537,7 +537,7 @@ import os
 os.environ['FZ_MAX_RETRIES'] = '3'  # Try each case up to 3 times
 
 results = fz.fzr(
-    "input.txt", model, var_values,
+    "input.txt", model, input_variables,
     calculators=[
         "sh://unreliable_calc.sh",  # Might fail
         "sh://backup_calc.sh"        # Backup method

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -386,12 +386,12 @@ fz.fzr("t2d_breach.cas",
         "S": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_S.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_S.csv\")}))'",
         "H": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_H.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_H.csv\")}))'"
     }
-},var_values={}, engine="python", calculators="sh:///bin/bash .fz/calculators/Telemac.sh", results_dir="result")
+},input_variables={}, engine="python", calculators="sh:///bin/bash .fz/calculators/Telemac.sh", results_dir="result")
 ```
 
 use cache and aliases for Telemac:
 ```python
-fz.fzr("t2d_breach.cas","Telemac",var_values={}, engine="python", calculators="*", results_dir="result")
+fz.fzr("t2d_breach.cas","Telemac",input_variables={}, engine="python", calculators="*", results_dir="result")
 ```
 
 # test ssh

--- a/fz/core.py
+++ b/fz/core.py
@@ -346,7 +346,7 @@ def fzi(input_path: str, model: Union[str, Dict]) -> Dict[str, None]:
 def fzc(
     input_path: str,
     model: Union[str, Dict],
-    var_values: Dict,
+    input_variables: Dict,
     engine: str = None,
     output_dir: str = "output",
 ) -> None:
@@ -356,7 +356,7 @@ def fzc(
     Args:
         input_path: Path to input file or directory
         model: Model definition dict or alias string
-        var_values: Dict of variable values or lists of values for grid
+        input_variables: Dict of variable values or lists of values for grid
         engine: Engine for formula evaluation ("python", "R", etc.)
         output_dir: Output directory for compiled files
     """
@@ -382,16 +382,16 @@ def fzc(
 
     # Generate all combinations if lists are provided
     var_combinations = []
-    var_names = list(var_values.keys())
+    var_names = list(input_variables.keys())
 
     # Check if any values are lists
-    has_lists = any(isinstance(v, list) for v in var_values.values())
+    has_lists = any(isinstance(v, list) for v in input_variables.values())
 
     if has_lists:
         # Convert single values to lists for consistency
         list_values = []
         for var in var_names:
-            val = var_values[var]
+            val = input_variables[var]
             if isinstance(val, list):
                 list_values.append(val)
             else:
@@ -401,7 +401,7 @@ def fzc(
         for combination in itertools.product(*list_values):
             var_combinations.append(dict(zip(var_names, combination)))
     else:
-        var_combinations = [var_values]
+        var_combinations = [input_variables]
 
     for i, var_combo in enumerate(var_combinations):
         # Create output subdirectory for this combination
@@ -731,7 +731,7 @@ def fzo(
 def fzr(
     input_path: str,
     model: Union[str, Dict],
-    var_values: Dict,
+    input_variables: Dict,
     engine: str = None,
     results_dir: str = "results",
     calculators: Union[str, List[str]] = None,
@@ -742,7 +742,7 @@ def fzr(
     Args:
         input_path: Path to input file or directory
         model: Model definition dict or alias string
-        var_values: Dict of variable values or lists of values for grid
+        input_variables: Dict of variable values or lists of values for grid
         engine: Engine for formula evaluation
         results_dir: Results directory
         calculators: Calculator specifications
@@ -798,13 +798,13 @@ def fzr(
     original_input_was_dir = input_path.is_dir()
 
     # Generate variable combinations
-    var_names = list(var_values.keys())
-    has_lists = any(isinstance(v, list) for v in var_values.values())
+    var_names = list(input_variables.keys())
+    has_lists = any(isinstance(v, list) for v in input_variables.values())
 
     if has_lists:
         list_values = []
         for var in var_names:
-            val = var_values[var]
+            val = input_variables[var]
             if isinstance(val, list):
                 list_values.append(val)
             else:
@@ -814,7 +814,7 @@ def fzr(
             dict(zip(var_names, combo)) for combo in itertools.product(*list_values)
         ]
     else:
-        var_combinations = [var_values]
+        var_combinations = [input_variables]
 
     # Prepare results structure
     results = {var: [] for var in var_names}
@@ -833,7 +833,7 @@ def fzr(
 
         # Compile all combinations directly to result directories, then prepare temp directories
         compile_to_result_directories(
-            input_path, model, var_values, engine, var_combinations, results_dir
+            input_path, model, input_variables, engine, var_combinations, results_dir
         )
 
         # Create temp directories and copy from result directories (excluding .fz_hash)

--- a/fz/engine.py
+++ b/fz/engine.py
@@ -94,14 +94,14 @@ def parse_variables_from_path(input_path: Path, varprefix: str = "$", delim: str
     return variables
 
 
-def replace_variables_in_content(content: str, var_values: Dict[str, Any],
+def replace_variables_in_content(content: str, input_variables: Dict[str, Any],
                                 varprefix: str = "$", delim: str = "()") -> str:
     """
     Replace variables in content with their values
 
     Args:
         content: Text content to process
-        var_values: Dict of variable values
+        input_variables: Dict of variable values
         varprefix: Variable prefix (e.g., "$")
         delim: Delimiter characters (e.g., "()")
 
@@ -111,7 +111,7 @@ def replace_variables_in_content(content: str, var_values: Dict[str, Any],
     # Replace variables
     if len(delim) == 2:
         left_delim, right_delim = delim[0], delim[1]
-        for var, val in var_values.items():
+        for var, val in input_variables.items():
             # Pattern for delimited variables: $var or $(var)
             esc_varprefix = re.escape(varprefix)
             esc_var = re.escape(var)
@@ -127,7 +127,7 @@ def replace_variables_in_content(content: str, var_values: Dict[str, Any],
                 content = re.sub(pattern, str(val), content)
     else:
         # Simple prefix-only variables
-        for var, val in var_values.items():
+        for var, val in input_variables.items():
             esc_varprefix = re.escape(varprefix)
             esc_var = re.escape(var)
             pattern = rf"{esc_varprefix}{esc_var}\b"
@@ -136,14 +136,14 @@ def replace_variables_in_content(content: str, var_values: Dict[str, Any],
     return content
 
 
-def evaluate_formulas(content: str, model: Dict, var_values: Dict, engine: str = "python") -> str:
+def evaluate_formulas(content: str, model: Dict, input_variables: Dict, engine: str = "python") -> str:
     """
     Evaluate formulas in content using specified engine
 
     Args:
         content: Text content containing formulas
         model: Model definition dict
-        var_values: Dict of variable values
+        input_variables: Dict of variable values
         engine: Engine for evaluation ("python", "R", etc.)
 
     Returns:
@@ -171,7 +171,7 @@ def evaluate_formulas(content: str, model: Dict, var_values: Dict, engine: str =
     # Setup engine environment
     if engine.lower() == "python":
         # Create execution environment
-        env = dict(var_values)  # Start with variable values
+        env = dict(input_variables)  # Start with variable values
 
         # Execute context lines (collect them first to handle multi-line functions)
         if context_lines:
@@ -214,7 +214,7 @@ def evaluate_formulas(content: str, model: Dict, var_values: Dict, engine: str =
             formula = match.group(1)
             try:
                 # Replace variables in formula with their values
-                for var, val in var_values.items():
+                for var, val in input_variables.items():
                     var_pattern = rf'\${re.escape(var)}\b'
                     formula = re.sub(var_pattern, str(val), formula)
 

--- a/fz/helpers.py
+++ b/fz/helpers.py
@@ -985,7 +985,7 @@ def run_cases_parallel(var_combinations: List[Dict], temp_path: Path, resultsdir
 
 
 
-def compile_to_result_directories(input_path: str, model: Dict, var_values: Dict,
+def compile_to_result_directories(input_path: str, model: Dict, input_variables: Dict,
                                  engine: str, var_combinations: List[Dict],
                                  resultsdir: Path) -> None:
     """
@@ -994,7 +994,7 @@ def compile_to_result_directories(input_path: str, model: Dict, var_values: Dict
     Args:
         input_path: Path to input file or directory
         model: Model definition dict
-        var_values: Dict of variable values
+        input_variables: Dict of variable values
         engine: Engine for formula evaluation
         var_combinations: List of variable combinations (cases)
         resultsdir: Results directory

--- a/tests/example_interrupt.py
+++ b/tests/example_interrupt.py
@@ -59,15 +59,15 @@ echo "Calculation complete for x=$x"
         }
 
         # Define variable values (10 cases)
-        var_values = {
+        input_variables = {
             "x": list(range(1, 11))  # [1, 2, 3, ..., 10]
         }
 
         results_dir = tmp_path / "results"
 
         print("Starting calculations...")
-        print(f"Cases to run: {len(var_values['x'])}")
-        print(f"Estimated time: ~{len(var_values['x']) * 3} seconds")
+        print(f"Cases to run: {len(input_variables['x'])}")
+        print(f"Estimated time: ~{len(input_variables['x']) * 3} seconds")
         print()
         print("Press Ctrl+C at any time to gracefully stop...")
         print()
@@ -77,7 +77,7 @@ echo "Calculation complete for x=$x"
             results = fzr(
                 str(input_dir),
                 model,
-                var_values,
+                input_variables,
                 results_dir=str(results_dir),
                 calculators=["sh://"]
             )

--- a/tests/test_case_dir_creation.py
+++ b/tests/test_case_dir_creation.py
@@ -58,7 +58,7 @@ echo "Location check completed" >> location_check.txt
         result1 = fzr(
             input_path="test_case_input.txt",
             model={"output": {"value": "echo 'Single case test'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://bash check_location_script.sh"],
             results_dir="single_case_test"
         )
@@ -92,7 +92,7 @@ echo "Location check completed" >> location_check.txt
         result2 = fzr(
             input_path="test_case_input.txt",
             model={"output": {"value": "echo 'Multiple case test'"}},
-            var_values={"param1": ["a", "b"], "param2": ["1", "2"]},
+            input_variables={"param1": ["a", "b"], "param2": ["1", "2"]},
             calculators=["sh://bash check_location_script.sh"],
             results_dir="multi_case_test"
         )

--- a/tests/test_current_dir_fix.py
+++ b/tests/test_current_dir_fix.py
@@ -47,7 +47,7 @@ def test_current_dir_fix():
             result = fzr(
                 input_path="test_input.txt",
                 model={"output": {"value": "echo 'Test completed'"}},
-                var_values={},
+                input_variables={},
                 calculators=["sh://bash test_script.sh"],
                 results_dir="current_dir_test"
             )

--- a/tests/test_debug_command_flow.py
+++ b/tests/test_debug_command_flow.py
@@ -32,7 +32,7 @@ def test_debug_command_flow():
         result = fzr(
             input_path="debug_input.txt",
             model={"output": {"value": "echo 'Debug test'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://bash debug_script.sh"],
             results_dir="debug_result"
         )

--- a/tests/test_examples_telemac.py
+++ b/tests/test_examples_telemac.py
@@ -85,7 +85,7 @@ def test_telemac_fzr(telemac_setup):
             "S": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_S.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_S.csv\")}))'",
             "H": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_H.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_H.csv\")}))'"
         }
-    }, var_values={}, engine="python", calculators="sh:///bin/bash .fz/calculators/Telemac.sh", results_dir="result")
+    }, input_variables={}, engine="python", calculators="sh:///bin/bash .fz/calculators/Telemac.sh", results_dir="result")
 
     assert len(result) >= 1
 
@@ -97,7 +97,7 @@ def test_telemac_with_aliases(telemac_setup):
     if not Path("t2d_breach.cas").exists() or not Path(".fz").exists():
         pytest.skip("Telemac setup files not found")
 
-    result = fz.fzr("t2d_breach.cas", "Telemac", var_values={}, engine="python", calculators="*", results_dir="result")
+    result = fz.fzr("t2d_breach.cas", "Telemac", input_variables={}, engine="python", calculators="*", results_dir="result")
 
     assert len(result) >= 1
 

--- a/tests/test_final_verification.py
+++ b/tests/test_final_verification.py
@@ -34,7 +34,7 @@ def test_final_verification():
         result1 = fzr(
             input_path="final_input.txt",
             model={"output": {"value": "echo 'Test 1 completed'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://bash final_test_script.sh"],
             results_dir="final_test_1"
         )
@@ -46,7 +46,7 @@ def test_final_verification():
         result2 = fzr(
             input_path="final_input.txt",
             model={"output": {"value": "echo 'Test 2 completed'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://echo 'No relative paths'"],
             results_dir="final_test_2"
         )

--- a/tests/test_interrupt_handling.py
+++ b/tests/test_interrupt_handling.py
@@ -33,7 +33,7 @@ def test_interrupt_sequential_execution(tmp_path):
     input_file.chmod(0o755)
 
     # Create multiple cases
-    var_values = {
+    input_variables = {
         "x": [1, 2, 3, 4, 5]  # 5 cases, each taking 3 seconds
     }
 
@@ -53,7 +53,7 @@ def test_interrupt_sequential_execution(tmp_path):
     results = fzr(
         str(input_dir),
         model,
-        var_values,
+        input_variables,
         results_dir=str(results_dir),
         calculators=["sh://"]
     )
@@ -93,7 +93,7 @@ def test_interrupt_parallel_execution(tmp_path):
     input_file.chmod(0o755)
 
     # Create multiple cases
-    var_values = {
+    input_variables = {
         "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # 10 cases
     }
 
@@ -112,7 +112,7 @@ def test_interrupt_parallel_execution(tmp_path):
     results = fzr(
         str(input_dir),
         model,
-        var_values,
+        input_variables,
         results_dir=str(results_dir),
         calculators=["sh://", "sh://"]  # 2 parallel calculators
     )
@@ -145,7 +145,7 @@ def test_graceful_cleanup_on_interrupt(tmp_path):
     input_file.write_text("#!/bin/bash\nsleep 5\necho 'done' > output.txt\n")
     input_file.chmod(0o755)
 
-    var_values = {"x": [1, 2, 3]}
+    input_variables = {"x": [1, 2, 3]}
 
     # Set up interrupt
     def send_interrupt():
@@ -163,7 +163,7 @@ def test_graceful_cleanup_on_interrupt(tmp_path):
         results = fzr(
             str(input_dir),
             model,
-            var_values,
+            input_variables,
             results_dir=str(results_dir),
             calculators=["sh://"]
         )

--- a/tests/test_multiple_input_files.py
+++ b/tests/test_multiple_input_files.py
@@ -158,7 +158,7 @@ def test_multiple_input_files_with_variables():
             print("\n🚀 Test 2: Running fzr with multiple input files and variable combinations")
 
             # Define variable values for multiple cases
-            var_values = {
+            input_variables = {
                 "T": [300, 350],        # Temperature (used in config.txt, boundary.inp, postprocess.py)
                 "P": [101325, 200000],  # Pressure (used in config.txt, boundary.inp)
                 "rho": [1.225, 1.0],    # Density (used in material.dat, postprocess.py)
@@ -170,7 +170,7 @@ def test_multiple_input_files_with_variables():
                 "dt": [0.001, 0.0005]   # Time step (used in solver.cfg)
             }
 
-            print(f"Variable combinations will create {2**len(var_values)} = {2**len(var_values)} cases")
+            print(f"Variable combinations will create {2**len(input_variables)} = {2**len(input_variables)} cases")
 
             # Run with ALL variables to ensure complete substitution
             test_vars = {
@@ -206,7 +206,7 @@ def test_multiple_input_files_with_variables():
             result = fzr(
                 input_path=str(input_files_dir),
                 model=model,
-                var_values=test_vars_small,
+                input_variables=test_vars_small,
                 calculators=["sh://./process_inputs.sh"],
                 results_dir=str(temp_dir_path / "multi_file_results")
             )

--- a/tests/test_output_files_location.py
+++ b/tests/test_output_files_location.py
@@ -47,7 +47,7 @@ echo "Final stdout message"
         result = fzr(
             input_path="test_input_files.txt",
             model={"output": {"value": "echo 'Model output'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://bash test_multi_output.sh"],
             results_dir="file_location_test"
         )

--- a/tests/test_path_resolution_simple.py
+++ b/tests/test_path_resolution_simple.py
@@ -102,7 +102,7 @@ fi
             result = fzr(
                 input_path="test_input.txt",  # Use a specific input file
                 model={"output": {"result": "cat output.txt | grep 'result = ' | awk '{print $NF}' || echo 'failed'"}},
-                var_values={},
+                input_variables={},
                 calculators=[case["calculator"]],
                 results_dir=f"test_{case['name']}"
             )

--- a/tests/test_perfectgaz_3calcs_all.py
+++ b/tests/test_perfectgaz_3calcs_all.py
@@ -54,7 +54,7 @@ def test_perfectgaz_3calcs_all():
                     "temperature": "cat temperature_result.txt"
                 }
             },
-            var_values={
+            input_variables={
                 "T_kelvin": temperatures,
                 "n_mol": amounts,
                 "V_m3": volumes

--- a/tests/test_perfectgaz_3calculators.py
+++ b/tests/test_perfectgaz_3calculators.py
@@ -57,7 +57,7 @@ def test_perfectgaz_3calculators():
                     "temperature": "cat temperature_result.txt"
                 }
             },
-            var_values={
+            input_variables={
                 "T_kelvin": temperatures,
                 "n_mol": amounts,
                 "V_m3": volumes,

--- a/tests/test_perfectgaz_comprehensive.py
+++ b/tests/test_perfectgaz_comprehensive.py
@@ -37,7 +37,7 @@ def test_perfectgaz_comprehensive():
         result = fzr(
             input_path="perfectgaz_input.txt",
             model={"output": {"pressure": "cat output.txt"}},
-            var_values={"T_K": temperatures},
+            input_variables={"T_K": temperatures},
             calculators=["sh://bash PerfectGazPressure.sh","sh://bash PerfectGazPressure.sh","sh://bash PerfectGazPressure.sh"],
             results_dir="perfectgaz_results"
         )

--- a/tests/test_perfectgaz_sourced.py
+++ b/tests/test_perfectgaz_sourced.py
@@ -51,7 +51,7 @@ def test_perfectgaz_sourced():
         result = fzr(
             input_path="perfectgaz_vars.txt",
             model={"output": {"pressure": "cat output.txt"}},
-            var_values={
+            input_variables={
                 "T_kelvin": temperatures,
                 "n_mol": amounts,
                 "V_m3": volumes

--- a/tests/test_random_failures.py
+++ b/tests/test_random_failures.py
@@ -220,7 +220,7 @@ def run_single_case(case, attempt_num=1):
         result = fzr(
             input_path=".",
             model={"output": {"result": "grep 'result = ' output.txt | tail -1 | awk '{print $NF}' || echo 'failed'"}},
-            var_values={},
+            input_variables={},
             calculators=[case["calculator"]],
             results_dir=f"test_result_{case_name}"
         )

--- a/tests/test_simple_absolute_paths.py
+++ b/tests/test_simple_absolute_paths.py
@@ -30,7 +30,7 @@ def test_absolute_path_resolution():
         result = fzr(
             input_path=".",
             model={"output": {"value": "echo 'Execution completed'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://bash test_script.sh"],
             results_dir="absolute_test_result"
         )

--- a/tests/test_timing_fix.py
+++ b/tests/test_timing_fix.py
@@ -62,7 +62,7 @@ echo "Final stderr message" >&2
             result = fzr(
                 input_path="timing_input.txt",
                 model={"output": {"value": "echo 'Timing test completed'"}},
-                var_values={},
+                input_variables={},
                 calculators=["sh://bash timing_test_script.sh"],
                 results_dir=f"timing_test_{test_num + 1}"
             )

--- a/tests/test_warning_and_tracking.py
+++ b/tests/test_warning_and_tracking.py
@@ -33,7 +33,7 @@ def test_warning_and_tracking():
         result = fzr(
             input_path="input_data.txt",
             model={"output": {"value": "echo 'Completed'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://bash test_warning_script.sh"],
             results_dir="warning_test_result"
         )
@@ -53,7 +53,7 @@ def test_warning_and_tracking():
         result2 = fzr(
             input_path="input_data.txt",
             model={"output": {"value": "echo 'No paths'"}},
-            var_values={},
+            input_variables={},
             calculators=["sh://echo 'No relative paths here'"],
             results_dir="no_warning_test"
         )


### PR DESCRIPTION
## Summary
- Rename parameter `var_values` to `input_variables` in all functions (fzc, fzr, and helper functions)
- Update all test files to use new parameter name
- Update documentation (README.md, examples.md, workflow files)

## Changes
- **Core files**: Updated function signatures in fz/core.py, fz/helpers.py, fz/engine.py
- **Tests**: Updated 18 test files
- **Documentation**: Updated README.md, examples/examples.md, .github/workflows/README.yml
- **Total**: 71 replacements across 24 files

## Testing
- All existing tests pass with the new parameter name
- No functional changes, purely a naming refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>