### PR TITLE
Reorder fzr and fzc arguments: input_variables now comes before model

### DIFF
--- a/.github/workflows/README.yml
+++ b/.github/workflows/README.yml
@@ -149,8 +149,8 @@ jobs:
         # Run all combinations (2 × 2 = 4 cases)
         results = fz.fzr(
             "input.txt",
-            model,
             input_variables,
+            model,
             calculators="sh://bash PerfectGazPressure.sh",
             results_dir="results"
         )
@@ -254,8 +254,8 @@ jobs:
             output_dir = tmpdir / "compiled"
             fz.fzc(
                 str(input_file),
-                model,
                 input_variables,
+                model,
                 output_dir=str(output_dir)
             )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,8 +149,8 @@ def test_your_feature():
         # Act
         results = fz.fzr(
             str(input_file),
-            model,
             {"param": [1, 2, 3]},
+            model,
             calculators="sh://bash script.sh",
             resultsdir=str(Path(tmpdir) / "results")
         )

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ input_variables = {
 # Run all combinations (4 × 3 = 12 cases)
 results = fz.fzr(
     "input.txt",
-    model,
     input_variables,
+    model,
     calculators="sh://bash PerfectGazPressure.sh",
     results_dir="results"
 )
@@ -205,20 +205,20 @@ input_variables = {
 # Compile single file
 fz.fzc(
     "input.txt",
-    model,
     input_variables,
+    model,
     output_dir="compiled"
 )
 
 # Compile with multiple value sets (creates subdirectories)
 fz.fzc(
     "input.txt",
-    model,
     {
         "T_celsius": [20, 30],  # 2 values
         "V_L": [5, 10],         # 2 values
         "n_mol": 1              # fixed
     },
+    model,
     output_dir="compiled_grid"
 )
 # Creates: compiled_grid/T_celsius=20,V_L=5/, T_celsius=20,V_L=10/, etc.
@@ -226,8 +226,8 @@ fz.fzc(
 
 **Parameters**:
 - `input_path`: Path to input file or directory
-- `model`: Model definition (dict or alias name)
 - `input_variables`: Dictionary of variable values (scalar or list)
+- `model`: Model definition (dict or alias name)
 - `engine`: Expression evaluator (`"python"` or `"R"`, default: `"python"`)
 - `output_dir`: Output directory path
 
@@ -287,12 +287,12 @@ model = {
 
 results = fz.fzr(
     input_path="input.txt",
-    model=model,
     input_variables={
         "temperature": [100, 200, 300],
         "pressure": [1, 10, 100],
         "concentration": 0.5
     },
+    model=model,
     calculators=["sh://bash calculate.sh"],
     results_dir="results"
 )
@@ -306,8 +306,8 @@ print(results)
 
 **Parameters**:
 - `input_path`: Input file or directory path
-- `model`: Model definition (dict or alias)
 - `input_variables`: Variable values (creates Cartesian product of lists)
+- `model`: Model definition (dict or alias)
 - `engine`: Expression evaluator (default: `"python"`)
 - `calculators`: Calculator URI(s) - string or list
 - `results_dir`: Results directory path
@@ -358,7 +358,7 @@ Store reusable models in `.fz/models/`:
 
 Use by name:
 ```python
-results = fz.fzr("input.txt", "perfectgas", input_variables)
+results = fz.fzr("input.txt", input_variables, "perfectgas")
 ```
 
 ### Formula Evaluation
@@ -484,7 +484,7 @@ Store calculator configurations in `.fz/calculators/`:
 
 Use by name:
 ```python
-results = fz.fzr("input.txt", "perfectgas", input_variables, calculators="cluster")
+results = fz.fzr("input.txt", input_variables, "perfectgas", calculators="cluster")
 ```
 
 ## Advanced Features
@@ -496,15 +496,17 @@ FZ automatically parallelizes when you have multiple cases and calculators:
 ```python
 # Sequential: 1 calculator, 10 cases → runs one at a time
 results = fz.fzr(
-    "input.txt", model,
+    "input.txt",
     {"temp": list(range(10))},
+    model,
     calculators="sh://bash calc.sh"
 )
 
 # Parallel: 3 calculators, 10 cases → 3 concurrent
 results = fz.fzr(
-    "input.txt", model,
+    "input.txt",
     {"temp": list(range(10))},
+    model,
     calculators=[
         "sh://bash calc.sh",
         "sh://bash calc.sh",
@@ -535,7 +537,9 @@ import os
 os.environ['FZ_MAX_RETRIES'] = '3'  # Try each case up to 3 times
 
 results = fz.fzr(
-    "input.txt", model, input_variables,
+    "input.txt",
+    input_variables,
+    model,
     calculators=[
         "sh://unreliable_calc.sh",  # Might fail
         "sh://backup_calc.sh"        # Backup method
@@ -556,16 +560,18 @@ Intelligent result reuse:
 ```python
 # First run
 results1 = fz.fzr(
-    "input.txt", model,
+    "input.txt",
     {"temp": [10, 20, 30]},
+    model,
     calculators="sh://expensive_calc.sh",
     results_dir="run1"
 )
 
 # Add more cases - reuse previous results
 results2 = fz.fzr(
-    "input.txt", model,
+    "input.txt",
     {"temp": [10, 20, 30, 40, 50]},  # 2 new cases
+    model,
     calculators=[
         "cache://run1",              # Check cache first
         "sh://expensive_calc.sh"     # Only run new cases
@@ -649,12 +655,12 @@ model = {
 # Parametric study
 results = fz.fzr(
     "input.txt",
-    model,
     {
         "n_mol": [1, 2, 3],
         "T_celsius": [10, 20, 30],
         "V_L": [5, 10]
     },
+    model,
     calculators="sh://bash PerfectGazPressure.sh",
     results_dir="perfectgas_results"
 )
@@ -693,12 +699,12 @@ model = {
 # Run on HPC cluster
 results = fz.fzr(
     "simulation_input/",
-    model,
     {
         "mesh_size": [100, 200, 400, 800],
         "timestep": [0.001, 0.01, 0.1],
         "iterations": 1000
     },
+    model,
     calculators=[
         "cache://previous_runs/*",  # Check cache first
         "ssh://user@hpc.university.edu/sbatch /path/to/submit.sh"
@@ -727,8 +733,8 @@ model = {
 
 results = fz.fzr(
     "input.txt",
-    model,
     {"param": list(range(100))},
+    model,
     calculators=[
         "cache://previous_results",           # 1. Check cache
         "sh://bash fast_but_unstable.sh",    # 2. Try fast method
@@ -845,8 +851,9 @@ Use caching to resume from where you left off:
 ```python
 # First run (interrupted after 50/100 cases)
 results1 = fz.fzr(
-    "input.txt", model,
+    "input.txt",
     {"param": list(range(100))},
+    model,
     calculators="sh://bash calc.sh",
     results_dir="results"
 )
@@ -854,8 +861,9 @@ print(f"Completed {len(results1)} cases before interrupt")
 
 # Resume using cache
 results2 = fz.fzr(
-    "input.txt", model,
+    "input.txt",
     {"param": list(range(100))},
+    model,
     calculators=[
         "cache://results",      # Reuse completed cases
         "sh://bash calc.sh"     # Run remaining cases
@@ -881,8 +889,8 @@ def main():
     try:
         results = fz.fzr(
             "input.txt",
-            model,
             {"param": list(range(1000))},  # Many cases
+            model,
             calculators="sh://bash slow_calculation.sh",
             results_dir="results"
         )
@@ -1010,8 +1018,8 @@ echo "result=$param" > output.txt
         # Run test
         results = fz.fzr(
             str(input_file),
-            model,
             {"param": [1, 2, 3]},
+            model,
             calculators=f"sh://bash {calc_script}",
             results_dir=str(Path(tmpdir) / "results")
         )

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -177,15 +177,15 @@ fz.fzi("input.txt",
 ```python
 fz.fzc("input.txt",
 {
+    "T_celsius": 20,
+    "V_L": 1,
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": 20,
-    "V_L": 1,
-    "n_mol": 1
 }, output_dir="output")
 ```
 
@@ -194,15 +194,15 @@ run calculation for one case
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": 20,
+    "V_L": 1,
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": 20,
-    "V_L": 1,
-    "n_mol": 1
 }, calculators="sh:///bin/bash ./PerfectGazPressure.sh", results_dir="result")
 ```
 
@@ -211,15 +211,15 @@ run calculation for many cases (factorial design of experiments)
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25,30],
+    "V_L": [1,1.5],
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25,30],
-    "V_L": [1,1.5],
-    "n_mol": 1
 }, calculators="sh:///bin/bash ./PerfectGazPressure.sh", results_dir="results")
 ```
 
@@ -232,15 +232,15 @@ test cache (all cases should be in cache, so no more calculation should be done)
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25,30],
+    "V_L": [1,1.5],
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25,30],
-    "V_L": [1,1.5],
-    "n_mol": 1
 }, calculators=["cache://results_*","sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 ```
 
@@ -252,15 +252,15 @@ here 2 calculators, 2 cases, so should run in 5 seconds instead of 10 seconds if
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25],
+    "V_L": 1,
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25],
-    "V_L": 1,
-    "n_mol": 1
 }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh","sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 ```
 
@@ -268,15 +268,15 @@ now 3 calculators, 2 cases, so should run in 5 seconds instead of 10 seconds if 
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25],
+    "V_L": 1,
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25],
-    "V_L": 1,
-    "n_mol": 1
 }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh","sh:///bin/bash ./PerfectGazPressure.sh","sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 ```
 
@@ -284,15 +284,15 @@ now 2 calculators, 3 cases, so should run in 10 seconds instead of 15 seconds if
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25,30],
+    "V_L": 1,
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25,30],
-    "V_L": 1,
-    "n_mol": 1
 }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh","sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 ```
 
@@ -312,26 +312,26 @@ fz.fzi("NewtonCooling.mo",
 ```python
 fz.fzc("NewtonCooling.mo",
 {
+    "convection": 123
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"res": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_res.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_res.csv\")}))'"}
-},{
-    "convection": 123
 }, output_dir="output")
 ```
 
 ```python
 results=fz.fzr("NewtonCooling.mo",
 {
+    "convection": [.123,.456, .789],
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"res": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_res.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_res.csv\")}))'"}
-},{
-    "convection": [.123,.456, .789],
 }, calculators="sh:///bin/bash ./Modelica.sh", results_dir="results")
 
 # plot temperature for the 3 cases
@@ -352,13 +352,13 @@ use cache of previous results
 ```python
 fz.fzr("NewtonCooling.mo",
 {
+    "convection": [.123,.456, .789],
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"res": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_res.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_res.csv\")}))'"}
-},{
-    "convection": [.123,.456, .789],
 }, calculators=["cache://results_*","sh:///bin/bash ./Modelica.sh"], results_dir="results")
 ```
 
@@ -376,7 +376,7 @@ fz.fzi("t2d_breach.cas",
 
 ```python
 fz.fzr("t2d_breach.cas",
-{
+input_variables={},{
     "id": "Telemac",
     "varprefix": "$",
     "formulaprefix": "@",
@@ -386,7 +386,7 @@ fz.fzr("t2d_breach.cas",
         "S": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_S.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_S.csv\")}))'",
         "H": "python -c 'import pandas;import glob;import json;print(json.dumps({f.split(\"_H.csv\")[0]:pandas.read_csv(f).to_dict() for f in glob.glob(\"*_H.csv\")}))'"
     }
-},input_variables={}, calculators="sh:///bin/bash .fz/calculators/Telemac.sh", results_dir="result")
+}, calculators="sh:///bin/bash .fz/calculators/Telemac.sh", results_dir="result")
 ```
 
 use cache and aliases for Telemac:
@@ -414,15 +414,15 @@ ssh_calculator=f"ssh://localhost//bin/bash {current_dir}/PerfectGazPressure.sh"
 
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,30,40],
+    "V_L": 1,
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,30,40],
-    "V_L": 1,
-    "n_mol": 1
 }, calculators=ssh_calculator, results_dir="results")
 ```
 
@@ -431,15 +431,15 @@ fz.fzr("input.txt",
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,30,40],
+    "V_L": [1,1.5],
+    "n_mol": 1
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,30,40],
-    "V_L": [1,1.5],
-    "n_mol": 1
 }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh"]*6, results_dir="results")
 ```
 
@@ -454,15 +454,15 @@ never fails
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25,30],
+    "V_L": [1,1.5],
+    "n_mol": [1,0]
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25,30],
-    "V_L": [1,1.5],
-    "n_mol": [1,0]  
 }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh"]*3, results_dir="results")
 ```
 
@@ -470,15 +470,15 @@ sometimes fails, but retries and succeeds (must return numerics for all pressure
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25,30],
+    "V_L": [1,1.5],
+    "n_mol": [1,0]
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25,30],
-    "V_L": [1,1.5],
-    "n_mol": [1,0] 
 }, calculators=["sh:///bin/bash ./PerfectGazPressureRandomFails.sh"]*3, results_dir="results")
 ```
 
@@ -486,15 +486,15 @@ always fails (must return None in all pressure values)
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25,30],
+    "V_L": [1,1.5],
+    "n_mol": [1,0]
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25,30],
-    "V_L": [1,1.5],
-    "n_mol": [1,0]
 }, calculators=["sh:///bin/bash ./PerfectGazPressureAlwaysFails.sh"]*3, results_dir="results")
 ```
 
@@ -502,15 +502,15 @@ now use previous results in cache, but as failed should run calculations again
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": [20,25,30],
+    "V_L": [1,1.5],
+    "n_mol": [1,0]
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": [20,25,30],
-    "V_L": [1,1.5],
-    "n_mol": [1,0]  
 }, calculators=["cache://_","sh:///bin/bash ./PerfectGazPressure.sh","sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 ```
 
@@ -520,14 +520,14 @@ with some wrong values "abc", should fail for these cases only
 ```python
 fz.fzr("input.txt",
 {
+    "T_celsius": ["20","25","abc"],
+    "V_L": [1,1.5],
+    "n_mol": [1,0]
+},{
     "varprefix": "$",
     "formulaprefix": "@",
     "delim": "()",
     "commentline": "#",
     "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-},{
-    "T_celsius": ["20","25","abc"],
-    "V_L": [1,1.5],
-    "n_mol": [1,0]  
 }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh"]*3, results_dir="results")
 ```

--- a/fz/cli.py
+++ b/fz/cli.py
@@ -73,7 +73,7 @@ def main():
         elif args.command == "fzc":
             model = parse_model(args.model)
             variables = parse_variables(args.variables)
-            fzc(args.input, model, variables, output_dir=args.output)
+            fzc(args.input, variables, model, output_dir=args.output)
             print(f"Compiled input saved to {args.output}")
 
         elif args.command == "fzo":
@@ -93,7 +93,7 @@ def main():
                 else:
                     calculators = json.loads(args.calculators)
 
-            result = fzr(args.input, model, variables,
+            result = fzr(args.input, variables, model,
                         results_dir=args.results,
                         calculators=calculators)
             print(json.dumps(result, indent=2))

--- a/fz/core.py
+++ b/fz/core.py
@@ -345,8 +345,8 @@ def fzi(input_path: str, model: Union[str, Dict]) -> Dict[str, None]:
 
 def fzc(
     input_path: str,
-    model: Union[str, Dict],
     input_variables: Dict,
+    model: Union[str, Dict],
     output_dir: str = "output",
 ) -> None:
     """
@@ -354,8 +354,8 @@ def fzc(
 
     Args:
         input_path: Path to input file or directory
-        model: Model definition dict or alias string
         input_variables: Dict of variable values or lists of values for grid
+        model: Model definition dict or alias string
         output_dir: Output directory for compiled files
     """
 
@@ -727,8 +727,8 @@ def fzo(
 
 def fzr(
     input_path: str,
-    model: Union[str, Dict],
     input_variables: Dict,
+    model: Union[str, Dict],
     results_dir: str = "results",
     calculators: Union[str, List[str]] = None,
 ) -> Union[Dict[str, List[Any]], "pandas.DataFrame"]:
@@ -737,8 +737,8 @@ def fzr(
 
     Args:
         input_path: Path to input file or directory
-        model: Model definition dict or alias string
         input_variables: Dict of variable values or lists of values for grid
+        model: Model definition dict or alias string
         results_dir: Results directory
         calculators: Calculator specifications
 

--- a/tests/example_interrupt.py
+++ b/tests/example_interrupt.py
@@ -76,8 +76,8 @@ echo "Calculation complete for x=$x"
         try:
             results = fzr(
                 str(input_dir),
-                model,
                 input_variables,
+                model,
                 results_dir=str(results_dir),
                 calculators=["sh://"]
             )

--- a/tests/example_usage.py
+++ b/tests/example_usage.py
@@ -56,7 +56,7 @@ calculated_value = @(calculate($base, $mult))
 
         # Set the formula interpreter (uses python by default)
         fz.set_interpreter("python")
-        fz.fzc(str(input_file), model, single_values,
+        fz.fzc(str(input_file), single_values, model,
                output_dir=str(output_dir))
 
         compiled_content = (output_dir / "input.txt").read_text()
@@ -69,7 +69,7 @@ calculated_value = @(calculate($base, $mult))
         multi_values = {"base": [2, 4, 6], "mult": [1, 2]}
         output_multi_dir = temp_path / "compiled_multi"
 
-        fz.fzc(str(input_file), model, multi_values,
+        fz.fzc(str(input_file), multi_values, model,
                output_dir=str(output_multi_dir))
 
         print(f"   Created {len(list(output_multi_dir.iterdir()))} combinations:")
@@ -92,7 +92,7 @@ calculated_value = @(calculate($base, $mult))
         try:
             # Create a simple mock calculator that just echoes
             results_all = fz.fzr(
-                str(input_file), model, {"base": [1, 2], "mult": [3, 4]},
+                str(input_file), {"base": [1, 2], "mult": [3, 4]}, model,
                 results_dir=str(temp_path / "results"),
                 calculators=["sh://echo 'The result is: calculated'"]
             )

--- a/tests/test_debug_execution.py
+++ b/tests/test_debug_execution.py
@@ -107,8 +107,8 @@ def test_debug_execution():
 
         start_time = time.time()
 
-        result = fz.fzr("input.txt", model, variables,
-                       
+        result = fz.fzr("input.txt", variables, model,
+
                        calculators=calculators,
                        results_dir="results")
 

--- a/tests/test_examples_advanced.py
+++ b/tests/test_examples_advanced.py
@@ -80,15 +80,15 @@ exit 1
 def test_parallel_2_calculators_2_cases(advanced_setup):
     """Test parallel execution with 2 calculators, 2 cases - from examples.md lines 253-265"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25],
+        "V_L": 1,
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25],
-        "V_L": 1,
-        "n_mol": 1
     }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh", "sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 
     assert len(result) == 2
@@ -98,15 +98,15 @@ def test_parallel_2_calculators_2_cases(advanced_setup):
 def test_parallel_3_calculators_2_cases(advanced_setup):
     """Test parallel execution with 3 calculators, 2 cases - from examples.md lines 268-281"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25],
+        "V_L": 1,
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25],
-        "V_L": 1,
-        "n_mol": 1
     }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh", "sh:///bin/bash ./PerfectGazPressure.sh", "sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 
     assert len(result) == 2
@@ -116,15 +116,15 @@ def test_parallel_3_calculators_2_cases(advanced_setup):
 def test_parallel_2_calculators_3_cases(advanced_setup):
     """Test parallel execution with 2 calculators, 3 cases - from examples.md lines 284-297"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": 1,
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": 1,
-        "n_mol": 1
     }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh", "sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 
     assert len(result) == 3
@@ -134,15 +134,15 @@ def test_parallel_2_calculators_3_cases(advanced_setup):
 def test_parallel_6_calculators_6_cases(advanced_setup):
     """Test parallel execution with 6 calculators, 6 cases - from examples.md lines 433-445"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 30, 40],
+        "V_L": [1, 1.5],
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 30, 40],
-        "V_L": [1, 1.5],
-        "n_mol": 1
     }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh"] * 6, results_dir="results")
 
     assert len(result) == 6
@@ -153,15 +153,15 @@ def test_parallel_fzo_result(advanced_setup):
     """Test fzo on parallel execution results - from examples.md lines 448-450"""
     # First run fzr
     fz.fzr("input.txt", {
+        "T_celsius": [20, 30, 40],
+        "V_L": [1, 1.5],
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 30, 40],
-        "V_L": [1, 1.5],
-        "n_mol": 1
     }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh"] * 6, results_dir="results")
 
     # Test fzo
@@ -173,15 +173,15 @@ def test_parallel_fzo_result(advanced_setup):
 def test_failure_never_fails(advanced_setup):
     """Test failure support - never fails - from examples.md lines 455-468"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": [1, 0]
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": [1, 0]
     }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh"] * 3, results_dir="results")
 
     assert len(result) == 12  # 3 * 2 * 2 = 12
@@ -192,15 +192,15 @@ def test_failure_never_fails(advanced_setup):
 def test_failure_random_fails_retries(advanced_setup):
     """Test failure support - sometimes fails but retries - from examples.md lines 471-484"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": [1, 0]
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": [1, 0]
     }, calculators=["sh:///bin/bash ./PerfectGazPressureRandomFails.sh"] * 3, results_dir="results")
 
     assert len(result) == 12
@@ -211,15 +211,15 @@ def test_failure_random_fails_retries(advanced_setup):
 def test_failure_always_fails(advanced_setup):
     """Test failure support - always fails - from examples.md lines 487-500"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": [1, 0]
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": [1, 0]
     }, calculators=["sh:///bin/bash ./PerfectGazPressureAlwaysFails.sh"] * 3, results_dir="results")
 
     assert len(result) == 12
@@ -233,28 +233,28 @@ def test_failure_cache_with_fallback(advanced_setup):
     """Test cache with fallback after failures - from examples.md lines 503-516"""
     # First run that will fail and cache failures
     fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": [1, 0]
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": [1, 0]
     }, calculators=["sh:///bin/bash ./PerfectGazPressureAlwaysFails.sh"] * 3, results_dir="results_fail")
 
     # Second run with cache and successful calculator
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": [1, 0]
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": [1, 0]
     }, calculators=["cache://_", "sh:///bin/bash ./PerfectGazPressure.sh", "sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results_fail")
 
     assert len(result) == 12
@@ -265,15 +265,15 @@ def test_failure_cache_with_fallback(advanced_setup):
 def test_non_numeric_variables(advanced_setup):
     """Test non-numeric variables with some wrong values - from examples.md lines 521-534"""
     result = fz.fzr("input.txt", {
+        "T_celsius": ["20", "25", "abc"],
+        "V_L": [1, 1.5],
+        "n_mol": [1, 0]
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": ["20", "25", "abc"],
-        "V_L": [1, 1.5],
-        "n_mol": [1, 0]
     }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh"] * 3, results_dir="results")
 
     assert len(result) == 12  # 3 * 2 * 2 = 12

--- a/tests/test_examples_perfectgaz.py
+++ b/tests/test_examples_perfectgaz.py
@@ -95,15 +95,15 @@ def test_perfectgaz_fzi(perfectgaz_setup):
 def test_perfectgaz_fzc(perfectgaz_setup):
     """Test fzc - from examples.md lines 178-190"""
     fz.fzc("input.txt", {
+        "T_celsius": 20,
+        "V_L": 1,
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": 20,
-        "V_L": 1,
-        "n_mol": 1
     }, output_dir="output")
 
     # Check if (relative) output directory is created
@@ -113,15 +113,15 @@ def test_perfectgaz_fzc(perfectgaz_setup):
 def test_perfectgaz_fzr_single_case(perfectgaz_setup):
     """Test fzr with single case - from examples.md lines 194-207"""
     result = fz.fzr("input.txt", {
+        "T_celsius": 20,
+        "V_L": 1,
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": 20,
-        "V_L": 1,
-        "n_mol": 1
     }, calculators="sh:///bin/bash ./PerfectGazPressure.sh", results_dir="result")
 
     assert len(result) == 1
@@ -131,15 +131,15 @@ def test_perfectgaz_fzr_single_case(perfectgaz_setup):
 def test_perfectgaz_fzr_factorial_design(perfectgaz_setup):
     """Test fzr with factorial design - from examples.md lines 211-224"""
     result = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": 1
     }, calculators="sh:///bin/bash ./PerfectGazPressure.sh", results_dir="results")
 
     assert len(result) == 6  # 3 * 2 combinations
@@ -149,15 +149,15 @@ def test_perfectgaz_fzo(perfectgaz_setup):
     """Test fzo to read results - from examples.md lines 227-229"""
     # First run fzr to create results
     fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": 1
     }, calculators="sh:///bin/bash ./PerfectGazPressure.sh", results_dir="results")
 
     # Now test fzo
@@ -170,28 +170,28 @@ def test_perfectgaz_cache(perfectgaz_setup):
     """Test cache usage - from examples.md lines 232-245"""
     # First run to populate cache
     result1 = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": 1
     }, calculators="sh:///bin/bash ./PerfectGazPressure.sh", results_dir="results_cache")
 
     # Second run should use cache
     result2 = fz.fzr("input.txt", {
+        "T_celsius": [20, 25, 30],
+        "V_L": [1, 1.5],
+        "n_mol": 1
+    }, {
         "varprefix": "$",
         "formulaprefix": "@",
         "delim": "()",
         "commentline": "#",
         "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
-    }, {
-        "T_celsius": [20, 25, 30],
-        "V_L": [1, 1.5],
-        "n_mol": 1
     }, calculators=["cache://results_cache*", "sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results_cache")
 
     assert len(result2) == 6

--- a/tests/test_final_specification.py
+++ b/tests/test_final_specification.py
@@ -77,8 +77,8 @@ def test_final_specification():
 
         start_time = time.time()
 
-        result = fz.fzr("input.txt", model, variables,
-                       
+        result = fz.fzr("input.txt", variables, model,
+
                        calculators=calculators,
                        results_dir="results")
 

--- a/tests/test_fzo_fzr_coherence.py
+++ b/tests/test_fzo_fzr_coherence.py
@@ -70,7 +70,7 @@ def test_fzo_fzr_coherence_single_case():
             variables = {"T": 300}
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://bash calc.sh",
                                 results_dir="test_results")
 
@@ -126,7 +126,7 @@ def test_fzo_fzr_coherence_multiple_cases():
             variables = {"T": [100, 200, 300], "P": [1, 2]}  # 6 cases
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://bash calc.sh",
                                 results_dir="multi_results")
 
@@ -188,7 +188,7 @@ def test_fzo_fzr_coherence_multiple_outputs():
             variables = {"X": [2, 3, 4, 5]}  # 4 cases
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://bash calc.sh",
                                 results_dir="multi_output_results")
 
@@ -249,8 +249,8 @@ def test_fzo_fzr_coherence_with_formulas():
             variables = {"base": [5, 10], "mult": [2, 3]}  # 4 cases
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
-                                
+            fzr_result = fz.fzr("input.txt", variables, model,
+
                                 calculators="sh://bash calc.sh",
                                 results_dir="formula_results")
 
@@ -306,7 +306,7 @@ def test_fzo_fzr_coherence_with_failures():
             variables = {"value": [1, 2, 3]}  # Case 2 will fail
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://bash calc.sh",
                                 results_dir="failure_results")
 
@@ -374,7 +374,7 @@ def test_fzo_fzr_coherence_perfectgaz_example():
             }  # 6 cases total
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://bash PerfectGazPressure.sh",
                                 results_dir="perfectgaz_results")
 
@@ -432,7 +432,7 @@ def test_fzo_fzr_coherence_simple_echo():
             variables = {"x": [1, 2, 3], "y": [10, 20]}  # 6 cases
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://sh calc.sh",
                                 results_dir="echo_results")
 
@@ -489,7 +489,7 @@ def test_fzo_fzr_coherence_three_variables():
             variables = {"a": [1, 2], "b": [10, 20], "c": [100, 200, 300]}
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://sh calc.sh",
                                 results_dir="three_var_results")
 
@@ -544,7 +544,7 @@ def test_fzo_fzr_coherence_float_values():
             variables = {"temp": [20.5, 25.0, 30.5], "pressure": [1.0, 1.5]}
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://sh calc.sh",
                                 results_dir="float_results")
 
@@ -595,7 +595,7 @@ def test_fzo_fzr_coherence_large_grid():
             variables = {"p1": [1, 2, 3, 4, 5], "p2": [10, 20, 30, 40]}
 
             # Run fzr
-            fzr_result = fz.fzr("input.txt", model, variables,
+            fzr_result = fz.fzr("input.txt", variables, model,
                                 calculators="sh://sh calc.sh",
                                 results_dir="large_grid_results")
 

--- a/tests/test_interrupt_handling.py
+++ b/tests/test_interrupt_handling.py
@@ -52,8 +52,8 @@ def test_interrupt_sequential_execution(tmp_path):
     # Run fzr - should be interrupted
     results = fzr(
         str(input_dir),
-        model,
         input_variables,
+        model,
         results_dir=str(results_dir),
         calculators=["sh://"]
     )
@@ -111,8 +111,8 @@ def test_interrupt_parallel_execution(tmp_path):
     # Run fzr with multiple calculators for parallel execution
     results = fzr(
         str(input_dir),
-        model,
         input_variables,
+        model,
         results_dir=str(results_dir),
         calculators=["sh://", "sh://"]  # 2 parallel calculators
     )
@@ -162,8 +162,8 @@ def test_graceful_cleanup_on_interrupt(tmp_path):
     try:
         results = fzr(
             str(input_dir),
-            model,
             input_variables,
+            model,
             results_dir=str(results_dir),
             calculators=["sh://"]
         )

--- a/tests/test_multiple_input_files.py
+++ b/tests/test_multiple_input_files.py
@@ -205,8 +205,8 @@ def test_multiple_input_files_with_variables():
 
             result = fzr(
                 input_path=str(input_files_dir),
-                model=model,
                 input_variables=test_vars_small,
+                model=model,
                 calculators=["sh://./process_inputs.sh"],
                 results_dir=str(temp_dir_path / "multi_file_results")
             )

--- a/tests/test_output_files_location.py
+++ b/tests/test_output_files_location.py
@@ -46,8 +46,8 @@ echo "Final stdout message"
         # Run the test
         result = fzr(
             input_path="test_input_files.txt",
-            model={"output": {"value": "echo 'Model output'"}},
             input_variables={},
+            model={"output": {"value": "echo 'Model output'"}},
             calculators=["sh://bash test_multi_output.sh"],
             results_dir="file_location_test"
         )

--- a/tests/test_parallel_simple.py
+++ b/tests/test_parallel_simple.py
@@ -34,8 +34,8 @@ def test_parallel_vs_single():
         start_time = time.time()
         results_single = fz.fzr(
             temp_input,
-            test_model,
             {"param": 1},
+            test_model,
             calculators=["sh://echo 'fast result' > result.txt"]
         )
         single_time = time.time() - start_time
@@ -46,8 +46,8 @@ def test_parallel_vs_single():
         start_time = time.time()
         results_parallel = fz.fzr(
             temp_input,
-            test_model,
             {"param": 1},
+            test_model,
             results_dir="results_parallel",
             calculators=[
                 "sh://sleep 2 && echo 'slow result' > result.txt",

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -103,14 +103,14 @@ def test_various_path_formats():
         try:
             result = fzr("input.txt",
             {
+                "X": [f"test_{i+1}"]
+            },
+            {
                 "varprefix": "$",
                 "delim": "()",
                 "output": {"result": "grep 'result = ' output.txt | awk '{print $3}' || echo 'none'"}
             },
-            {
-                "X": [f"test_{i+1}"]
-            },
-            
+
             calculators=[test_case['calculator']],
             results_dir=f"path_test_{i+1}")
 

--- a/tests/test_perfectgaz_3calculators.py
+++ b/tests/test_perfectgaz_3calculators.py
@@ -50,18 +50,18 @@ def test_perfectgaz_3calculators():
         # Run the test with 3 calculators
         result = fzr(
             input_path="perfectgaz_3calc_vars.txt",
+            input_variables={
+                "T_kelvin": temperatures,
+                "n_mol": amounts,
+                "V_m3": volumes,
+                "pressure_pa": pressures
+            },
             model={
                 "output": {
                     "pressure": "cat output.txt",
                     "volume": "cat volume_result.txt",
                     "temperature": "cat temperature_result.txt"
                 }
-            },
-            input_variables={
-                "T_kelvin": temperatures,
-                "n_mol": amounts,
-                "V_m3": volumes,
-                "pressure_pa": pressures
             },
             calculators=[
                 "sh:///bin/bash ./PerfectGazPressure.sh",

--- a/tests/test_perfectgaz_sourced.py
+++ b/tests/test_perfectgaz_sourced.py
@@ -50,12 +50,12 @@ def test_perfectgaz_sourced():
         # Run the comprehensive test
         result = fzr(
             input_path="perfectgaz_vars.txt",
-            model={"output": {"pressure": "cat output.txt"}},
             input_variables={
                 "T_kelvin": temperatures,
                 "n_mol": amounts,
                 "V_m3": volumes
             },
+            model={"output": {"pressure": "cat output.txt"}},
             calculators=["sh:///bin/bash ./PerfectGazPressure.sh"],
             results_dir="perfectgaz_sourced_results"
         )

--- a/tests/test_random_failures.py
+++ b/tests/test_random_failures.py
@@ -219,8 +219,8 @@ def run_single_case(case, attempt_num=1):
 
         result = fzr(
             input_path=".",
-            model={"output": {"result": "grep 'result = ' output.txt | tail -1 | awk '{print $NF}' || echo 'failed'"}},
             input_variables={},
+            model={"output": {"result": "grep 'result = ' output.txt | tail -1 | awk '{print $NF}' || echo 'failed'"}},
             calculators=[case["calculator"]],
             results_dir=f"test_result_{case_name}"
         )

--- a/tests/test_retry_mechanism.py
+++ b/tests/test_retry_mechanism.py
@@ -64,14 +64,14 @@ def test_retry_success():
 
     result = fzr("input.txt",
     {
+        "T_celsius": [20, 30]
+    },
+    {
         "varprefix": "$",
         "delim": "()",
         "output": {"result": "grep 'result = ' output.txt | awk '{print $3}'"}
     },
-    {
-        "T_celsius": [20, 30]
-    },
-    
+
     calculators=[
         "sh:///bin/bash ./FailThenSuccess.sh",  # Fails first time
         "sh:///bin/bash ./AlwaysSucceeds.sh"    # Should succeed on retry
@@ -95,14 +95,14 @@ def test_all_fail():
 
     result = fzr("input.txt",
     {
+        "T_celsius": [40]
+    },
+    {
         "varprefix": "$",
         "delim": "()",
         "output": {"result": "grep 'result = ' output.txt | awk '{print $3}'"}
     },
-    {
-        "T_celsius": [40]
-    },
-    
+
     calculators=[
         "sh:///bin/bash ./AlwaysFails.sh",     # Always fails
         "sh:///bin/bash ./AlwaysFails.sh"      # Also always fails
@@ -126,14 +126,14 @@ def test_first_succeeds():
 
     result = fzr("input.txt",
     {
+        "T_celsius": [50]
+    },
+    {
         "varprefix": "$",
         "delim": "()",
         "output": {"result": "grep 'result = ' output.txt | awk '{print $3}'"}
     },
-    {
-        "T_celsius": [50]
-    },
-    
+
     calculators=[
         "sh:///bin/bash ./AlwaysSucceeds.sh",   # Should succeed immediately
         "sh:///bin/bash ./FailThenSuccess.sh"   # Won't be tried

--- a/tests/test_robust_parallel.py
+++ b/tests/test_robust_parallel.py
@@ -90,8 +90,8 @@ def test_robust_parallel():
 
         start_time = time.time()
 
-        result = fz.fzr("input.txt", model, variables,
-                       
+        result = fz.fzr("input.txt", variables, model,
+
                        calculators=calculators,
                        results_dir="results")
 

--- a/tests/test_simple_absolute_paths.py
+++ b/tests/test_simple_absolute_paths.py
@@ -29,8 +29,8 @@ def test_absolute_path_resolution():
         # Run a command that creates output in the original directory
         result = fzr(
             input_path=".",
-            model={"output": {"value": "echo 'Execution completed'"}},
             input_variables={},
+            model={"output": {"value": "echo 'Execution completed'"}},
             calculators=["sh://bash test_script.sh"],
             results_dir="absolute_test_result"
         )

--- a/tests/test_timing_fix.py
+++ b/tests/test_timing_fix.py
@@ -61,8 +61,8 @@ echo "Final stderr message" >&2
 
             result = fzr(
                 input_path="timing_input.txt",
-                model={"output": {"value": "echo 'Timing test completed'"}},
                 input_variables={},
+                model={"output": {"value": "echo 'Timing test completed'"}},
                 calculators=["sh://bash timing_test_script.sh"],
                 results_dir=f"timing_test_{test_num + 1}"
             )

--- a/tests/test_user_example.py
+++ b/tests/test_user_example.py
@@ -66,17 +66,18 @@ def test_user_example():
         start_time = time.time()
         result = fzr("input.txt",
         {
+            "T_celsius": [20,30,40],
+            "V_L": 1,
+            "n_mol": 1
+        },
+        {
             "varprefix": "$",
             "formulaprefix": "@",
             "delim": "()",
             "commentline": "#",
             "output": {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
         },
-        {
-            "T_celsius": [20,30,40],
-            "V_L": 1,
-            "n_mol": 1
-        }, calculators=["sh:///bin/bash ./PerfectGazPressure.sh","sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
+        calculators=["sh:///bin/bash ./PerfectGazPressure.sh","sh:///bin/bash ./PerfectGazPressure.sh"], results_dir="results")
 
         elapsed = time.time() - start_time
         print(f"\n🏁 Test completed in {elapsed:.2f}s")

--- a/tests/test_warning_and_tracking.py
+++ b/tests/test_warning_and_tracking.py
@@ -32,8 +32,8 @@ def test_warning_and_tracking():
         # Test with a command that should trigger path resolution
         result = fzr(
             input_path="input_data.txt",
-            model={"output": {"value": "echo 'Completed'"}},
             input_variables={},
+            model={"output": {"value": "echo 'Completed'"}},
             calculators=["sh://bash test_warning_script.sh"],
             results_dir="warning_test_result"
         )
@@ -52,8 +52,8 @@ def test_warning_and_tracking():
 
         result2 = fzr(
             input_path="input_data.txt",
-            model={"output": {"value": "echo 'No paths'"}},
             input_variables={},
+            model={"output": {"value": "echo 'No paths'"}},
             calculators=["sh://echo 'No relative paths here'"],
             results_dir="no_warning_test"
         )


### PR DESCRIPTION
## Summary

This PR reorders the arguments of `fzr()` and `fzc()` functions so that `input_variables` comes immediately after `input_path`, before `model`.

**New signature:**
- `fzr(input_path, input_variables, model, ...)`
- `fzc(input_path, input_variables, model, ...)`

**Old signature:**
- `fzr(input_path, model, input_variables, ...)`
- `fzc(input_path, model, input_variables, ...)`

## Changes

- Updated function definitions in `fz/core.py`
- Updated all function calls in code (`fz/cli.py`)
- Updated all test files (~27 files, ~92 function calls)
- Updated CI workflows (`.github/workflows/README.yml`)
- Updated documentation (`README.md`, `examples.md`, `CONTRIBUTING.md`)

## Test plan

- [x] All function definitions updated with new argument order
- [x] All code usages updated
- [x] All test files updated
- [x] CI workflows updated
- [x] Documentation updated
- [ ] Run test suite to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)