### PR TITLE
Add CLI argument aliases so the documented README forms work

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### CLI argument aliases (README forms now work)
+
+- Input/output paths can be passed positionally: `fzi input.txt -m mymodel`.
+- New flag aliases matching the documented forms: `--variables` (= `--input_variables`),
+  `--calculator` (= `--calculators`, now repeatable), `--results` (= `--results_dir`),
+  `--output` (= `--output_dir`).
+- Inline model definition without `--model`: `--varprefix`, `--formulaprefix`, `--delim`,
+  `--commentline`, `--interpreter`, and repeatable `--output-cmd NAME=COMMAND`. When
+  combined with `--model`, the inline flags override the loaded model definition.
+- All canonical flags and short options are unchanged; `--model` is no longer required
+  (defaults: varprefix `$`, formulaprefix `@`, delim `{}`, commentline `#`).
+
 ### CLI hardening for scripting and AI agents
 
 - Log messages (`FZ_LOG_LEVEL`) and progress output now go to **stderr** instead of

--- a/fz/cli.py
+++ b/fz/cli.py
@@ -150,6 +150,115 @@ def parse_algorithm_options(opts_str):
     """Parse algorithm options from JSON string or JSON file"""
     return parse_argument(opts_str, alias_type=None)
 
+
+# Shared argument groups for the standalone commands and `fz` subcommands.
+# They accept both the canonical flags (--input_variables, --calculators,
+# --results_dir, --output_dir) and the documented aliases (--variables,
+# --calculator, --results, --output), plus positional paths and inline model
+# definition without --model.
+
+_MODEL_FIELD_ARGS = ("varprefix", "formulaprefix", "delim", "commentline", "interpreter")
+_DEFAULT_MODEL = {"varprefix": "$", "formulaprefix": "@", "delim": "{}", "commentline": "#"}
+
+
+def _add_input_path_args(parser):
+    parser.add_argument("input_path_pos", nargs="?", default=None, metavar="input_path",
+                        help="Input file or directory")
+    parser.add_argument("--input_path", "-i", default=None,
+                        help="Input file or directory (alternative to positional)")
+
+
+def _add_output_path_args(parser):
+    parser.add_argument("output_path_pos", nargs="?", default=None, metavar="output_path",
+                        help="Output file or directory")
+    parser.add_argument("--output_path", "-o", default=None,
+                        help="Output file or directory (alternative to positional)")
+
+
+def _resolve_path(parser, flag_value, pos_value, name):
+    if flag_value and pos_value and flag_value != pos_value:
+        parser.error(f"{name} given twice: positional '{pos_value}' and --{name} '{flag_value}'")
+    value = flag_value or pos_value
+    if not value:
+        parser.error(f"{name} is required (positional or --{name})")
+    return value
+
+
+def _add_model_args(parser):
+    parser.add_argument("--model", "-m", default=None,
+                        help="Model definition (JSON file, inline JSON, or alias)")
+    parser.add_argument("--varprefix", default=None, help="Variable prefix (default: $)")
+    parser.add_argument("--formulaprefix", default=None, help="Formula prefix (default: @)")
+    parser.add_argument("--delim", default=None,
+                        help="Variable/formula delimiters (default: {})")
+    parser.add_argument("--commentline", default=None,
+                        help="Comment line character (default: #)")
+    parser.add_argument("--interpreter", default=None,
+                        help="Formula interpreter: python or R")
+    parser.add_argument("--output-cmd", dest="output_cmd", action="append", default=None,
+                        metavar="NAME=COMMAND",
+                        help='Output parsing command, e.g. result="cat output.txt" (repeatable)')
+
+
+def _resolve_model(parser, args):
+    """Build the model from --model and/or the inline definition flags"""
+    inline = {field: getattr(args, field) for field in _MODEL_FIELD_ARGS
+              if getattr(args, field, None) is not None}
+    output_cmds = {}
+    for spec in (getattr(args, "output_cmd", None) or []):
+        if "=" not in spec:
+            parser.error(f"--output-cmd expects NAME=COMMAND, got '{spec}'")
+        name, cmd = spec.split("=", 1)
+        output_cmds[name.strip()] = cmd
+
+    if args.model:
+        model = parse_model(args.model)
+        # Inline flags refine an existing model definition
+        if isinstance(model, dict) and (inline or output_cmds):
+            model = dict(model)
+            model.update(inline)
+            if output_cmds:
+                merged = dict(model.get("output", {}))
+                merged.update(output_cmds)
+                model["output"] = merged
+        return model
+
+    model = dict(_DEFAULT_MODEL)
+    model.update(inline)
+    if output_cmds:
+        model["output"] = output_cmds
+    return model
+
+
+def _add_variables_arg(parser, required=True):
+    parser.add_argument("--input_variables", "--variables", "-v", dest="input_variables",
+                        required=required, help="Variable values (JSON file or inline JSON)")
+
+
+def _add_calculators_arg(parser):
+    parser.add_argument("--calculators", "--calculator", "-c", dest="calculators",
+                        action="append", default=None,
+                        help="Calculator URI, alias, JSON file, or JSON list (repeatable)")
+
+
+def _resolve_calculators(args):
+    if not args.calculators:
+        return None
+    calculators = []
+    for item in args.calculators:
+        parsed = parse_calculators(item)
+        if isinstance(parsed, list):
+            calculators.extend(parsed)
+        elif parsed is not None:
+            calculators.append(parsed)
+    return calculators
+
+
+def _add_format_arg(parser):
+    parser.add_argument("--format", "-f", default="markdown",
+                        choices=["json", "csv", "html", "markdown", "table"],
+                        help="Output format (default: markdown)")
+
 def format_output(data, format_type='markdown'):
     """
     Format output data in various formats
@@ -397,17 +506,16 @@ def fzi_main():
     """Entry point for fzi command"""
     parser = argparse.ArgumentParser(description="fzi - Parse input to find variables")
     parser.add_argument("--version", action="version", version=f"fzi {get_version()}")
-    parser.add_argument("--input_path", "-i", required=True, help="Input file or directory")
-    parser.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser.add_argument("--format", "-f", default="markdown",
-                        choices=["json", "csv", "html", "markdown", "table"],
-                        help="Output format (default: markdown)")
+    _add_input_path_args(parser)
+    _add_model_args(parser)
+    _add_format_arg(parser)
 
     args = parser.parse_args()
 
     try:
-        model = parse_model(args.model)
-        result = fzi_func(args.input_path, model)
+        input_path = _resolve_path(parser, args.input_path, args.input_path_pos, "input_path")
+        model = _resolve_model(parser, args)
+        result = fzi_func(input_path, model)
         print(format_output(result, args.format))
         return 0
     except TypeError as e:
@@ -429,17 +537,19 @@ def fzc_main():
     """Entry point for fzc command"""
     parser = argparse.ArgumentParser(description="fzc - Compile input with variable values")
     parser.add_argument("--version", action="version", version=f"fzc {get_version()}")
-    parser.add_argument("--input_path", "-i", required=True, help="Input file or directory")
-    parser.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser.add_argument("--input_variables", "-v", required=True, help="Variable values (JSON file or inline JSON)")
-    parser.add_argument("--output_dir", "-o", default="output", help="Output directory (default: output)")
+    _add_input_path_args(parser)
+    _add_model_args(parser)
+    _add_variables_arg(parser)
+    parser.add_argument("--output_dir", "--output", "-o", dest="output_dir", default="output",
+                        help="Output directory (default: output)")
 
     args = parser.parse_args()
 
     try:
-        model = parse_model(args.model)
+        input_path = _resolve_path(parser, args.input_path, args.input_path_pos, "input_path")
+        model = _resolve_model(parser, args)
         variables = parse_variables(args.input_variables)
-        fzc_func(args.input_path, variables, model, output_dir=args.output_dir)
+        fzc_func(input_path, variables, model, output_dir=args.output_dir)
         print(f"Compiled input saved to {args.output_dir}")
         return 0
     except TypeError as e:
@@ -461,17 +571,16 @@ def fzo_main():
     """Entry point for fzo command"""
     parser = argparse.ArgumentParser(description="fzo - Parse output files")
     parser.add_argument("--version", action="version", version=f"fzo {get_version()}")
-    parser.add_argument("--output_path", "-o", required=True, help="Output file or directory")
-    parser.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser.add_argument("--format", "-f", default="markdown",
-                        choices=["json", "csv", "html", "markdown", "table"],
-                        help="Output format (default: markdown)")
+    _add_output_path_args(parser)
+    _add_model_args(parser)
+    _add_format_arg(parser)
 
     args = parser.parse_args()
 
     try:
-        model = parse_model(args.model)
-        result = fzo_func(args.output_path, model)
+        output_path = _resolve_path(parser, args.output_path, args.output_path_pos, "output_path")
+        model = _resolve_model(parser, args)
+        result = fzo_func(output_path, model)
         print(format_output(result, args.format))
         return 0
     except TypeError as e:
@@ -493,23 +602,23 @@ def fzr_main():
     """Entry point for fzr command"""
     parser = argparse.ArgumentParser(description="fzr - Run full parametric calculations")
     parser.add_argument("--version", action="version", version=f"fzr {get_version()}")
-    parser.add_argument("--input_path", "-i", required=True, help="Input file or directory")
-    parser.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser.add_argument("--input_variables", "-v", required=True, help="Variable values (JSON file or inline JSON)")
-    parser.add_argument("--results_dir", "-r", default="results", help="Results directory (default: results)")
-    parser.add_argument("--calculators", "-c", help="Calculator specifications (JSON file or inline JSON)")
-    parser.add_argument("--format", "-f", default="markdown",
-                        choices=["json", "csv", "html", "markdown", "table"],
-                        help="Output format (default: markdown)")
+    _add_input_path_args(parser)
+    _add_model_args(parser)
+    _add_variables_arg(parser)
+    parser.add_argument("--results_dir", "--results", "-r", dest="results_dir", default="results",
+                        help="Results directory (default: results)")
+    _add_calculators_arg(parser)
+    _add_format_arg(parser)
 
     args = parser.parse_args()
 
     try:
-        model = parse_model(args.model)
+        input_path = _resolve_path(parser, args.input_path, args.input_path_pos, "input_path")
+        model = _resolve_model(parser, args)
         variables = parse_variables(args.input_variables)
-        calculators = parse_calculators(args.calculators) if args.calculators else None
+        calculators = _resolve_calculators(args)
 
-        result = fzr_func(args.input_path, variables, model,
+        result = fzr_func(input_path, variables, model,
                     results_dir=args.results_dir,
                     calculators=calculators)
         print(format_output(result, args.format))
@@ -602,37 +711,33 @@ def main():
 
     # input command (fzi)
     parser_input = subparsers.add_parser("input", help="Parse input to find variables")
-    parser_input.add_argument("--input_path", "-i", required=True, help="Input file or directory")
-    parser_input.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser_input.add_argument("--format", "-f", default="markdown",
-                              choices=["json", "csv", "html", "markdown", "table"],
-                              help="Output format (default: markdown)")
+    _add_input_path_args(parser_input)
+    _add_model_args(parser_input)
+    _add_format_arg(parser_input)
 
     # compile command (fzc)
     parser_compile = subparsers.add_parser("compile", help="Compile input with variable values")
-    parser_compile.add_argument("--input_path", "-i", required=True, help="Input file or directory")
-    parser_compile.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser_compile.add_argument("--input_variables", "-v", required=True, help="Variable values (JSON file or inline JSON)")
-    parser_compile.add_argument("--output_dir", "-o", default="output", help="Output directory (default: output)")
+    _add_input_path_args(parser_compile)
+    _add_model_args(parser_compile)
+    _add_variables_arg(parser_compile)
+    parser_compile.add_argument("--output_dir", "--output", "-o", dest="output_dir",
+                                default="output", help="Output directory (default: output)")
 
     # output command (fzo)
     parser_output = subparsers.add_parser("output", help="Parse output files")
-    parser_output.add_argument("--output_path", "-o", required=True, help="Output file or directory")
-    parser_output.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser_output.add_argument("--format", "-f", default="markdown",
-                               choices=["json", "csv", "html", "markdown", "table"],
-                               help="Output format (default: markdown)")
+    _add_output_path_args(parser_output)
+    _add_model_args(parser_output)
+    _add_format_arg(parser_output)
 
     # run command (fzr)
     parser_run = subparsers.add_parser("run", help="Run full parametric calculations")
-    parser_run.add_argument("--input_path", "-i", required=True, help="Input file or directory")
-    parser_run.add_argument("--model", "-m", required=True, help="Model definition (JSON file, inline JSON, or alias)")
-    parser_run.add_argument("--input_variables", "-v", required=True, help="Variable values (JSON file or inline JSON)")
-    parser_run.add_argument("--results_dir", "-r", default="results", help="Results directory (default: results)")
-    parser_run.add_argument("--calculators", "-c", help="Calculator specifications (JSON file or inline JSON)")
-    parser_run.add_argument("--format", "-f", default="markdown",
-                            choices=["json", "csv", "html", "markdown", "table"],
-                            help="Output format (default: markdown)")
+    _add_input_path_args(parser_run)
+    _add_model_args(parser_run)
+    _add_variables_arg(parser_run)
+    parser_run.add_argument("--results_dir", "--results", "-r", dest="results_dir",
+                            default="results", help="Results directory (default: results)")
+    _add_calculators_arg(parser_run)
+    _add_format_arg(parser_run)
 
     # design command (fzd)
     parser_design = subparsers.add_parser("design", help="Iterative design of experiments with algorithms")
@@ -697,27 +802,31 @@ def main():
 
     try:
         if args.command == "input":
-            model = parse_model(args.model)
-            result = fzi_func(args.input_path, model)
+            input_path = _resolve_path(parser, args.input_path, args.input_path_pos, "input_path")
+            model = _resolve_model(parser, args)
+            result = fzi_func(input_path, model)
             print(format_output(result, args.format))
 
         elif args.command == "compile":
-            model = parse_model(args.model)
+            input_path = _resolve_path(parser, args.input_path, args.input_path_pos, "input_path")
+            model = _resolve_model(parser, args)
             variables = parse_variables(args.input_variables)
-            fzc_func(args.input_path, variables, model, output_dir=args.output_dir)
+            fzc_func(input_path, variables, model, output_dir=args.output_dir)
             print(f"Compiled input saved to {args.output_dir}")
 
         elif args.command == "output":
-            model = parse_model(args.model)
-            result = fzo_func(args.output_path, model)
+            output_path = _resolve_path(parser, args.output_path, args.output_path_pos, "output_path")
+            model = _resolve_model(parser, args)
+            result = fzo_func(output_path, model)
             print(format_output(result, args.format))
 
         elif args.command == "run":
-            model = parse_model(args.model)
+            input_path = _resolve_path(parser, args.input_path, args.input_path_pos, "input_path")
+            model = _resolve_model(parser, args)
             variables = parse_variables(args.input_variables)
-            calculators = parse_calculators(args.calculators) if args.calculators else None
+            calculators = _resolve_calculators(args)
 
-            result = fzr_func(args.input_path, variables, model,
+            result = fzr_func(input_path, variables, model,
                         results_dir=args.results_dir,
                         calculators=calculators)
             print(format_output(result, args.format))

--- a/skills/fz/reference.md
+++ b/skills/fz/reference.md
@@ -95,23 +95,30 @@ Every Python function has a CLI twin: `fzi`, `fzc`, `fzo`, `fzr`, `fzl`, `fzd`
 (also available as subcommands: `fz run ...`, `fz design ...`). `fz install model|algorithm
 <name|git-url>` installs aliases into `.fz/` (`--global` for `~/.fz/`).
 
-Flags per command (all flags, no positional arguments):
+Flags per command:
 
 ```
-fzi  --input_path/-i  --model/-m  --format/-f
-fzc  --input_path/-i  --model/-m  --input_variables/-v  --output_dir/-o
-fzo  --output_path/-o --model/-m  --format/-f
-fzr  --input_path/-i  --model/-m  --input_variables/-v  --results_dir/-r
+fzi  [input_path]  --input_path/-i  --model/-m  --format/-f
+fzc  [input_path]  --input_path/-i  --model/-m  --input_variables/-v  --output_dir/-o
+fzo  [output_path] --output_path/-o --model/-m  --format/-f
+fzr  [input_path]  --input_path/-i  --model/-m  --input_variables/-v  --results_dir/-r
      --calculators/-c  --format/-f
 fzl  --models/-m  --calculators/-c  --check  --format/-f
 fzd  --input_dir/-i  --input_vars/-v  --model/-m  --output_expression/-e
      --algorithm/-a  --results_dir/-r  --calculators/-c  --options/-o
 ```
 
+- Input/output paths may be given positionally (`fzi input.txt -m mymodel`) or via flag.
+- Aliases: `--variables` = `--input_variables`; `--calculator` = `--calculators`
+  (repeatable: `--calculator "cache://run1" --calculator "sh://bash calc.sh"`);
+  `--results` = `--results_dir`; `--output` = `--output_dir`.
 - `--format` accepts: `json`, `csv`, `html`, `markdown`, `table`.
 - `--model`, `--input_variables`, `--calculators` auto-detect their format: alias (bare
-  name) → JSON file path (ends in `.json`) → inline JSON. Multiple calculators are passed
-  as one inline JSON list: `--calculators '["cache://run1", "sh://bash calc.sh"]'`.
+  name) → JSON file path (ends in `.json`) → inline JSON. Multiple calculators may also be
+  one inline JSON list: `--calculators '["cache://run1", "sh://bash calc.sh"]'`.
+- Inline model definition (instead of, or overriding, `--model`): `--varprefix`,
+  `--formulaprefix`, `--delim`, `--commentline`, `--interpreter`, and repeatable
+  `--output-cmd NAME=COMMAND` for output parsers.
 - `--input_vars` (fzd) takes JSON with `"[min;max]"` range strings for varied variables.
 
 Stream discipline: results go to stdout; logs (`FZ_LOG_LEVEL`), progress bar, and error

--- a/tests/test_cli_aliases.py
+++ b/tests/test_cli_aliases.py
@@ -13,8 +13,14 @@ from pathlib import Path
 from test_cli_commands import run_fz_cli_function
 
 
+def _write_file(path, content):
+    # Path.write_text(newline=...) needs Python 3.10+; open() works on 3.9
+    with Path(path).open("w", newline="\n") as f:
+        f.write(content)
+
+
 def _write_input(content="x=$x\n"):
-    Path("input.txt").write_text(content, newline="\n")
+    _write_file("input.txt", content)
 
 
 class TestPositionalPaths:
@@ -28,7 +34,7 @@ class TestPositionalPaths:
 
     def test_fzo_positional_output(self):
         Path("odir").mkdir()
-        (Path("odir") / "output.txt").write_text("42\n", newline="\n")
+        _write_file(Path("odir") / "output.txt", "42\n")
         result = run_fz_cli_function("fzo_main", [
             "odir", "--output-cmd", "y=cat output.txt", "--format", "json",
         ])
@@ -63,7 +69,7 @@ class TestFlagAliases:
 
     def test_fzr_repeatable_calculator_and_results_alias(self):
         _write_input()
-        Path("calc.sh").write_text("#!/bin/bash\necho 42 > output.txt\n", newline="\n")
+        _write_file("calc.sh", "#!/bin/bash\necho 42 > output.txt\n")
         result = run_fz_cli_function("fzr_main", [
             "input.txt",
             "--model", '{"varprefix": "$", "output": {"y": "cat output.txt"}}',
@@ -110,8 +116,8 @@ class TestInlineModel:
 
     def test_output_cmd_merges_into_model(self):
         Path("odir").mkdir()
-        (Path("odir") / "output.txt").write_text("7\n", newline="\n")
-        (Path("odir") / "other.txt").write_text("8\n", newline="\n")
+        _write_file(Path("odir") / "output.txt", "7\n")
+        _write_file(Path("odir") / "other.txt", "8\n")
         result = run_fz_cli_function("fzo_main", [
             "odir", "--model", '{"output": {"a": "cat output.txt"}}',
             "--output-cmd", "b=cat other.txt", "--format", "json",

--- a/tests/test_cli_aliases.py
+++ b/tests/test_cli_aliases.py
@@ -1,0 +1,130 @@
+"""
+Tests for the CLI argument aliases documented in the README:
+
+- positional input/output paths (fzi input.txt ... instead of -i input.txt)
+- --variables (= --input_variables), --calculator (= --calculators, repeatable),
+  --results (= --results_dir), --output (= --output_dir)
+- inline model definition without --model: --varprefix, --formulaprefix,
+  --delim, --commentline, --interpreter, --output-cmd NAME=COMMAND
+"""
+import json
+from pathlib import Path
+
+from test_cli_commands import run_fz_cli_function
+
+
+def _write_input(content="x=$x\n"):
+    Path("input.txt").write_text(content, newline="\n")
+
+
+class TestPositionalPaths:
+    def test_fzi_positional_input(self):
+        _write_input()
+        result = run_fz_cli_function("fzi_main", [
+            "input.txt", "--model", '{"varprefix": "$"}', "--format", "json",
+        ])
+        assert result.returncode == 0, result.stderr
+        assert "x" in json.loads(result.stdout)
+
+    def test_fzo_positional_output(self):
+        Path("odir").mkdir()
+        (Path("odir") / "output.txt").write_text("42\n", newline="\n")
+        result = run_fz_cli_function("fzo_main", [
+            "odir", "--output-cmd", "y=cat output.txt", "--format", "json",
+        ])
+        assert result.returncode == 0, result.stderr
+        assert "42" in result.stdout
+
+    def test_positional_and_flag_conflict_is_an_error(self):
+        _write_input()
+        result = run_fz_cli_function("fzi_main", [
+            "input.txt", "--input_path", "other.txt", "--format", "json",
+        ])
+        assert result.returncode != 0
+        assert "twice" in result.stderr
+
+    def test_missing_path_is_an_error(self):
+        result = run_fz_cli_function("fzi_main", ["--format", "json"])
+        assert result.returncode != 0
+        assert "required" in result.stderr.lower()
+
+
+class TestFlagAliases:
+    def test_fzc_variables_and_output_aliases(self):
+        _write_input()
+        result = run_fz_cli_function("fzc_main", [
+            "input.txt", "--model", '{"varprefix": "$"}',
+            "--variables", '{"x": 5}', "--output", "compiled",
+        ])
+        assert result.returncode == 0, result.stderr
+        compiled = Path("compiled/x=5/input.txt")
+        assert compiled.exists()
+        assert "x=5" in compiled.read_text()
+
+    def test_fzr_repeatable_calculator_and_results_alias(self):
+        _write_input()
+        Path("calc.sh").write_text("#!/bin/bash\necho 42 > output.txt\n", newline="\n")
+        result = run_fz_cli_function("fzr_main", [
+            "input.txt",
+            "--model", '{"varprefix": "$", "output": {"y": "cat output.txt"}}',
+            "--variables", '{"x": [1, 2]}',
+            "--calculator", "cache://_no_such_dir_",
+            "--calculator", "sh://bash calc.sh",
+            "--results", "myresults",
+            "--format", "json",
+        ])
+        assert result.returncode == 0, result.stderr
+        records = json.loads(result.stdout)
+        assert len(records) == 2
+        assert all(r["status"] == "done" for r in records)
+        assert Path("myresults").exists()
+
+    def test_canonical_flags_still_work(self):
+        _write_input()
+        result = run_fz_cli_function("fzc_main", [
+            "-i", "input.txt", "-m", '{"varprefix": "$"}',
+            "-v", '{"x": 9}', "-o", "compiled_canonical",
+        ])
+        assert result.returncode == 0, result.stderr
+        assert Path("compiled_canonical/x=9/input.txt").exists()
+
+
+class TestInlineModel:
+    def test_fzi_inline_model_without_model_flag(self):
+        _write_input()
+        result = run_fz_cli_function("fzi_main", [
+            "input.txt", "--varprefix", "$", "--delim", "{}", "--format", "json",
+        ])
+        assert result.returncode == 0, result.stderr
+        assert "x" in json.loads(result.stdout)
+
+    def test_inline_flags_override_model(self):
+        # File uses $x; the model says varprefix %, the inline flag overrides to $
+        _write_input()
+        result = run_fz_cli_function("fzi_main", [
+            "input.txt", "--model", '{"varprefix": "%"}',
+            "--varprefix", "$", "--format", "json",
+        ])
+        assert result.returncode == 0, result.stderr
+        assert "x" in json.loads(result.stdout)
+
+    def test_output_cmd_merges_into_model(self):
+        Path("odir").mkdir()
+        (Path("odir") / "output.txt").write_text("7\n", newline="\n")
+        (Path("odir") / "other.txt").write_text("8\n", newline="\n")
+        result = run_fz_cli_function("fzo_main", [
+            "odir", "--model", '{"output": {"a": "cat output.txt"}}',
+            "--output-cmd", "b=cat other.txt", "--format", "json",
+        ])
+        assert result.returncode == 0, result.stderr
+        record = json.loads(result.stdout)[0]
+        assert record["a"] == 7
+        assert record["b"] == 8
+
+    def test_malformed_output_cmd_is_an_error(self):
+        Path("odir").mkdir()
+        result = run_fz_cli_function("fzo_main", [
+            "odir", "--output-cmd", "no_equals_sign", "--format", "json",
+        ])
+        assert result.returncode != 0
+        assert "NAME=COMMAND" in result.stderr

--- a/tests/test_skill_static.py
+++ b/tests/test_skill_static.py
@@ -82,15 +82,16 @@ class TestSkillCodeDrift:
 
     def test_documented_cli_flags_exist(self):
         """Every --flag mentioned in the skill is a real argparse option"""
-        real_flags = set(re.findall(r'add_argument\(\s*"(--[a-z_]+)"', CLI_SRC))
-        real_flags |= {
-            short
-            for short in re.findall(r'add_argument\(\s*"--[a-z_]+",\s*"(-[a-z])"', CLI_SRC)
-        }
+        # Any double-quoted long flag in cli.py is an argparse option string
+        # (including aliases like --variables given as secondary option strings)
+        real_flags = set(re.findall(r'"(--[a-z][a-z_-]*)"', CLI_SRC))
+        real_flags |= set(re.findall(r'"(-[a-z])"', CLI_SRC))
         real_flags |= {"--help", "--version"}
         documented = set()
         for md in SKILL_FILES:
-            documented |= set(re.findall(r"(?<!-)(--[a-z_]+)", md.read_text(encoding="utf-8")))
+            documented |= set(
+                re.findall(r"(?<!-)(--[a-z][a-z_-]*)", md.read_text(encoding="utf-8"))
+            )
         unknown = documented - real_flags
         assert not unknown, f"skill documents CLI flags that do not exist: {sorted(unknown)}"
 


### PR DESCRIPTION
## Summary

The README documents CLI forms that argparse never accepted (found by the new skill drift tests): positional input paths, `--variables`, repeatable `--calculator`, `--results`, `--output`, and inline model definition flags. This PR makes those forms real instead of rewriting the README:

- **Positional paths**: `fzi input.txt -m mymodel` (also fzc/fzo/fzr and the `fz input/compile/output/run` subcommands). Flag and positional both accepted; passing both with different values is an error.
- **Flag aliases**: `--variables` = `--input_variables`, `--calculator` = `--calculators` (now repeatable; each value may be a URI, alias, JSON file or JSON list), `--results` = `--results_dir`, `--output` = `--output_dir`.
- **Inline model definition** without `--model`: `--varprefix`, `--formulaprefix`, `--delim`, `--commentline`, `--interpreter`, repeatable `--output-cmd NAME=COMMAND`. Combined with `--model`, the inline flags override the loaded definition.
- `--model` is no longer required (defaults: `$` `@` `{}` `#`).
- All canonical flags and short options are unchanged.

Internally the argument groups are defined once by shared `_add_*`/`_resolve_*` helpers used by both the standalone commands and the `fz` subcommands.

## Test plan

- [x] `tests/test_cli_aliases.py` (new, 11 tests): every README form, conflict/error cases, canonical flags still working
- [x] existing CLI tests pass unchanged (`tests/test_cli_commands.py`)
- [x] skill static drift tests updated to recognize aliased argparse option strings
- [x] live smoke tests of all README example forms (fzi/fzc/fzo/fzr + `fz` subcommands)
- [x] full local suite with CI exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)