### PR TITLE
Fix calculator discovery bugs; add wrapper implementation guide to the skill

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,16 @@
 - All canonical flags and short options are unchanged; `--model` is no longer required
   (defaults: varprefix `$`, formulaprefix `@`, delim `{}`, commentline `#`).
 
+### Calculator discovery fixes
+
+- `fzd` with `calculators` omitted now auto-discovers installed calculator aliases bound
+  to the model id, exactly like `fzr`. Previously it resolved calculators before reading
+  the model id, producing an empty `sh://` command and failing every case.
+- `fzr` (and thus `--calculators <alias>` on the CLI) now accepts calculator dicts; bare
+  alias names resolved from `.fz/calculators/` were previously rejected with a TypeError.
+- `fzd` docstring corrected: `analysis_dir` defaults to `"analysis"` (the CLI uses
+  `results_fzd`).
+
 ### CLI hardening for scripting and AI agents
 
 - Log messages (`FZ_LOG_LEVEL`) and progress output now go to **stderr** instead of

--- a/fz/core.py
+++ b/fz/core.py
@@ -1325,7 +1325,7 @@ def fzr(
     input_variables: Union[Dict, "pandas.DataFrame"],
     model: Union[str, Dict],
     results_dir: str = "results",
-    calculators: Union[str, List[str]] = None,
+    calculators: Union[str, Dict, List[Union[str, Dict]]] = None,
     callbacks: Optional[Dict[str, callable]] = None,
     timeout: int = None,
 ) -> Union[Dict[str, List[Any]], "pandas.DataFrame"]:
@@ -1378,12 +1378,12 @@ def fzr(
         raise TypeError(f"results_dir must be a string or Path, got {type(results_dir).__name__}")
 
     if calculators is not None:
-        if not isinstance(calculators, (str, list)):
-            raise TypeError(f"calculators must be a string or list, got {type(calculators).__name__}")
+        if not isinstance(calculators, (str, list, dict)):
+            raise TypeError(f"calculators must be a string, dict, or list, got {type(calculators).__name__}")
         if isinstance(calculators, list):
             for i, calc in enumerate(calculators):
-                if not isinstance(calc, str):
-                    raise TypeError(f"calculators[{i}] must be a string, got {type(calc).__name__}")
+                if not isinstance(calc, (str, dict)):
+                    raise TypeError(f"calculators[{i}] must be a string or dict, got {type(calc).__name__}")
 
     # Validate callbacks parameter
     if callbacks is not None:
@@ -1728,12 +1728,14 @@ def fzd(
         model: Model definition dict or alias string
         output_expression: Expression to extract from output files, e.g. "output1 + output2 * 2"
         algorithm: Path to algorithm Python file (e.g., "algorithms/montecarlo.py")
-        calculators: Calculator specifications (default: ["sh://"])
+        calculators: Calculator specifications. If omitted, installed calculator
+            aliases supporting the model id are auto-discovered (like fzr);
+            falls back to ["sh://"] when none are found.
         algorithm_options: Algorithm-specific options. Can be:
             - Dict: {"batch_size": 10, "max_iter": 100}
             - JSON string: '{"batch_size": 10, "max_iter": 100}'
             - JSON file path: "options.json"
-        analysis_dir: Analysis results directory (default: "results_fzd")
+        analysis_dir: Analysis results directory (default: "analysis"; the CLI uses "results_fzd")
 
     Returns:
         Dict with algorithm results including:
@@ -1790,11 +1792,13 @@ def fzd(
     try:
         model = _resolve_model(model)
 
-        # Parse calculator argument (handles JSON string, file, or alias)
-        calculators = _resolve_calculators_arg(calculators)
-
-        # Get model ID for calculator resolution
+        # Get model ID first: passing it to _resolve_calculators_arg lets an
+        # omitted calculators argument auto-discover installed calculator
+        # aliases bound to this model, exactly like fzr does
         model_id = model.get("id") if isinstance(model, dict) else None
+
+        # Parse calculator argument (handles JSON string, file, or alias)
+        calculators = _resolve_calculators_arg(calculators, model_name=model_id)
         calculators = resolve_calculators(calculators, model_id)
 
         # Convert to absolute paths

--- a/skills/fz/SKILL.md
+++ b/skills/fz/SKILL.md
@@ -18,22 +18,58 @@ fz wraps any simulation code that reads input files and writes output files, so 
 run as a parametric study: variables in input files are substituted for each case, cases run
 in parallel (locally, SSH, SLURM), and outputs are parsed back into a pandas DataFrame.
 
-Install: `pip install funz-fz` (CLI commands `fz`, `fzi`, `fzc`, `fzo`, `fzr`, `fzl`, `fzd`
-plus the `fz` Python package).
+Install: `pip install 'funz-fz>=1.0'` (CLI commands `fz`, `fzi`, `fzc`, `fzo`, `fzr`, `fzl`,
+`fzd` plus the `fz` Python package; `fz install` requires 1.0+). On PEP 668
+externally-managed systems (`error: externally-managed-environment`), use a venv:
+`python3 -m venv .venv && .venv/bin/pip install 'funz-fz>=1.0'`.
 
 ## The workflow
 
 Wrapping a simulation always follows the same steps. Do them in order and verify each one
 before moving to the next — this isolates errors cheaply instead of debugging a full run.
 
+0. **Check for an official wrapper**: `fz install model <code>` may give you steps 1–2
+   for free.
 1. **Parameterize the input file(s)**: replace numerical values with `$var` markers.
 2. **Define the model**: a small dict/JSON saying how to recognize variables and how to
-   parse outputs.
+   parse outputs — only if step 0 found no wrapper.
 3. **Verify parsing**: `fzi` must report exactly the variables you expect.
 4. **Verify compilation**: `fzc` with one set of values; inspect the compiled file.
 5. **Run one case manually**: execute the simulation command on the compiled file.
 6. **Verify output parsing**: `fzo` on the directory containing the outputs.
 7. **Run the study**: `fzr` with the full variable grid and calculator(s).
+
+### 0. Check for an existing wrapper first
+
+Funz publishes ready-made wrappers for common simulation codes (Modelica, MORET, …) as
+GitHub repos named `fz-<code>` under the Funz organization — browse
+<https://github.com/orgs/Funz/repositories?q=fz-> for the list. Install one with:
+
+```bash
+fz install model modelica        # name → https://github.com/Funz/fz-modelica
+fz list --check --format json    # verify what got installed
+```
+
+This drops into the project's `.fz/` directory (add `--global` for `~/.fz/`):
+
+- `.fz/models/<Code>.json` — the model definition (variable syntax + output parsers);
+  refer to it by bare alias, e.g. `--model Modelica`.
+- `.fz/calculators/<Code>.sh` — a runner script that executes the simulation code.
+- `.fz/calculators/localhost_<Code>.json` — a local calculator alias wired to that script.
+  In `fzr` it is auto-discovered: omit `calculators` and the installed alias matching the
+  model id is used. **fz 1.0 (current PyPI) caveats**: bare alias names are NOT accepted
+  by `--calculators`, and `fzd` does NOT auto-discover — omitting `calculators` there
+  silently runs an empty `sh://` command and every case fails; pass calculators explicitly
+  to `fzd`, e.g. a URI with an absolute script path:
+  `calculators="sh://bash /abs/path/.fz/calculators/<Code>.sh"` (absolute, because
+  calculator commands run inside each case directory). Both limitations are fixed in
+  newer fz (git main / next release): `fzd` auto-discovers like `fzr`, and
+  `--calculators <alias>` works.
+
+With a wrapper installed, skip to step 1 just to add `$var` markers to your input file,
+then verify with steps 3–6 as usual. Write a custom model (step 2) only when no wrapper
+exists for your code — and if it should be reusable or published as `fz-<code>`, follow
+[wrapper.md](wrapper.md).
 
 ### 1. Parameterize input files
 
@@ -131,6 +167,10 @@ fzr --input_path input.txt --model perfectgas \
   constrained combinations, or designs imported from CSV).
 - Returns a DataFrame with one row per case: variable columns, output columns, and
   metadata columns `status` (`done`/`error`/`cached`), `calculator`, `error`, `command`.
+- List-valued outputs (e.g. time series) become list columns — one whole trajectory per
+  row. The Modelica wrapper, for instance, yields `res_<Model>_time`, `res_<Model>_T`, …
+  per case; plot directly with
+  `for _, row in results.iterrows(): plt.plot(row["res_M_time"], row["res_M_T"])`.
 - Each case directory under `results/` keeps compiled inputs, outputs, `out.txt`,
   `err.txt`, `log.txt` — read these to diagnose failed cases.
 - Failed cases are retried automatically on another calculator (default 5 attempts,
@@ -159,7 +199,9 @@ fzr --input_path input.txt --model m --input_variables '...' \
 
 Calculator aliases live in `.fz/calculators/<name>.json` with the command per model id:
 `{"uri": "ssh://user@cluster", "models": {"perfectgas": "bash /path/calc.sh"}}`.
-Run `fzl --check --format json` to list and validate installed models/calculators.
+Run `fz list --check --format json` (alias `fzl`) to list and validate installed
+models/calculators — prefer the `fz <subcommand>` forms, which survive stale or
+partially-installed standalone scripts.
 
 ## Design of experiments / optimization (fzd)
 
@@ -180,6 +222,30 @@ results["XY"]       # DataFrame of all evaluated points
 results["summary"]  # text summary (e.g. optimum found)
 ```
 
+Like model wrappers, **algorithms can be installed** from the Funz GitHub organization —
+prefer this over writing one when the question goes beyond a plain sweep (optimization,
+calibration/inversion, uncertainty propagation, sensitivity analysis, adaptive sampling):
+
+```bash
+fz install algorithm brent        # name → https://github.com/Funz/fz-brent
+```
+
+Algorithm repos share the `fz-<name>` naming with model wrappers — browse
+<https://github.com/orgs/Funz/repositories?q=fz-> for both (as of 2026-06: `fz-brent`,
+`fz-gradientdescent`, `fz-PSO`; the `algorithm-*` repos are legacy Java-Funz). The fz repo
+itself also ships ready-to-use algorithms in `examples/algorithms/` (`montecarlo_uniform`,
+`randomsampling`, `bfgs`, `brent`) — copy one into `.fz/algorithms/`:
+
+```bash
+curl -s https://raw.githubusercontent.com/Funz/fz/main/examples/algorithms/montecarlo_uniform.py \
+  -o .fz/algorithms/montecarlo_uniform.py
+```
+
+Installed algorithms land in `.fz/algorithms/` (`--global` for `~/.fz/`) and are referenced
+by bare name (or glob): `algorithm="montecarlo_uniform"`. Check the `#options:` and
+`#require:` header lines of the algorithm file for its options and Python dependencies
+(e.g. montecarlo_uniform needs scipy).
+
 Points already evaluated are cached across iterations and across re-runs. To write a custom
 algorithm (a Python class with `get_initial_design` / `get_next_design` / `get_analysis`),
 read [algorithms.md](algorithms.md).
@@ -190,6 +256,9 @@ read [algorithms.md](algorithms.md).
   output is a human table. Data goes to stdout; logs, progress, and errors go to stderr.
   Exit codes are non-zero on errors, and `fzr` exits 1 when no case succeeded.
 - fz requires bash: native on Linux/macOS; MSYS2/Git Bash on Windows (`FZ_SHELL_PATH`).
+- Installed wrappers may invoke `python` (not `python3`) in their `output` commands and
+  import pandas — if output parsing returns nothing, run fz with a suitable interpreter
+  first on PATH: `PATH=$PWD/.venv/bin:$PATH fz output ...` (same for `fzr`).
 - In `output` parsing commands, awk field references like `$3` must survive shell quoting:
   in JSON model files write them normally; inside a single-quoted inline `--model` JSON
   argument they are safe as-is, but never wrap them in double quotes on the shell.

--- a/skills/fz/reference.md
+++ b/skills/fz/reference.md
@@ -93,7 +93,10 @@ fz.set_interpreter("R")        # formula interpreter: "python" (default) or "R"
 
 Every Python function has a CLI twin: `fzi`, `fzc`, `fzo`, `fzr`, `fzl`, `fzd`
 (also available as subcommands: `fz run ...`, `fz design ...`). `fz install model|algorithm
-<name|git-url>` installs aliases into `.fz/` (`--global` for `~/.fz/`).
+<name|git-url>` installs aliases into `.fz/` (`--global` for `~/.fz/`): a bare name resolves
+to `https://github.com/Funz/fz-<name>` (official wrappers, e.g. `fz-modelica`; browse
+<https://github.com/orgs/Funz/repositories?q=fz->), and the install provides the model JSON
+plus calculator script/alias. `fz uninstall model|algorithm <name>` removes them.
 
 Flags per command:
 
@@ -108,14 +111,19 @@ fzd  --input_dir/-i  --input_vars/-v  --model/-m  --output_expression/-e
      --algorithm/-a  --results_dir/-r  --calculators/-c  --options/-o
 ```
 
-- Input/output paths may be given positionally (`fzi input.txt -m mymodel`) or via flag.
-- Aliases: `--variables` = `--input_variables`; `--calculator` = `--calculators`
-  (repeatable: `--calculator "cache://run1" --calculator "sh://bash calc.sh"`);
-  `--results` = `--results_dir`; `--output` = `--output_dir`.
+- In fz 1.0 (current PyPI release), paths must be given via flag
+  (`fzi --input_path input.txt -m mymodel`) and only the canonical flag names below work.
+  Newer fz (git main / next release) additionally accepts positional paths
+  (`fzi input.txt -m mymodel`) and the aliases `--variables` = `--input_variables`,
+  `--calculator` = `--calculators` (repeatable), `--results` = `--results_dir`,
+  `--output` = `--output_dir`. The canonical flags work everywhere — prefer them.
 - `--format` accepts: `json`, `csv`, `html`, `markdown`, `table`.
-- `--model`, `--input_variables`, `--calculators` auto-detect their format: alias (bare
-  name) → JSON file path (ends in `.json`) → inline JSON. Multiple calculators may also be
-  one inline JSON list: `--calculators '["cache://run1", "sh://bash calc.sh"]'`.
+- `--model` and `--input_variables` auto-detect their format: alias (bare name) → JSON
+  file path (ends in `.json`) → inline JSON. `--calculators` takes a URI, JSON file path,
+  or inline JSON — in fz 1.0 NOT a bare alias name (newer fz accepts aliases too); omit it
+  entirely to auto-discover installed calculator aliases matching the model id (fzr always;
+  fzd only in newer fz — in 1.0 pass fzd calculators explicitly). Multiple calculators may
+  also be one inline JSON list: `--calculators '["cache://run1", "sh://bash calc.sh"]'`.
 - Inline model definition (instead of, or overriding, `--model`): `--varprefix`,
   `--formulaprefix`, `--delim`, `--commentline`, `--interpreter`, and repeatable
   `--output-cmd NAME=COMMAND` for output parsers.

--- a/skills/fz/wrapper.md
+++ b/skills/fz/wrapper.md
@@ -1,0 +1,154 @@
+# Implementing an fz wrapper (code binding)
+
+How to package fz support for a simulation code as a reusable, installable wrapper —
+the `fz-<code>` repositories that `fz install model <code>` consumes. Read this when the
+task is "make fz support code X" or "publish an fz binding", rather than wrapping a code
+ad hoc for one study (for that, [SKILL.md](SKILL.md) steps 1–2 suffice).
+
+## What a wrapper is
+
+A wrapper bundles, for one simulation code:
+
+1. a **model JSON** — how to recognize variables in input files and parse outputs;
+2. a **runner script** — how to launch the code on a compiled input file;
+3. a **calculator alias** — wiring the script to the model on the local machine.
+
+Installed with `fz install model <code>`, used with `--model <Code>` and (in `fzr`)
+auto-discovered calculators. No Python code is involved — a wrapper is data + shell.
+
+## Repository layout
+
+The convention consumed by the installer (`fz/installer.py`):
+
+```
+fz-mycode/                         # GitHub repo named fz-<code> (lowercase)
+├── .fz/
+│   ├── models/
+│   │   └── MyCode.json            # the model definition (file name = alias)
+│   └── calculators/
+│       ├── MyCode.sh              # runner script (made executable on install)
+│       └── localhost_MyCode.json  # local calculator alias
+├── tests/                         # recommended: a tiny end-to-end case
+│   ├── input.txt                  # parameterized sample input
+│   └── test.sh                    # runs the SKILL.md steps 3–6 against it
+└── README.md
+```
+
+- A bare name resolves to `https://github.com/Funz/fz-<code>` (official wrappers live
+  under the Funz organization; any git URL or local zip also works:
+  `fz install model https://github.com/you/fz-mycode.git`).
+- On install, `.fz/models/MyCode.json` is copied to the project's (or, with `--global`,
+  the user's) `.fz/models/`; every other `.fz/` subdirectory (`calculators/`, optionally
+  `algorithms/`) is copied wholesale, and `.sh`/`.bash`/`.zsh` scripts are made executable.
+
+## 1. The model JSON
+
+```json
+{
+    "id": "MyCode",
+    "varprefix": "$",
+    "formulaprefix": "@",
+    "delim": "{}",
+    "commentline": "#",
+    "output": {
+        "energy": "grep 'Total energy' out/results.log | awk '{print $4}'",
+        "trajectory": "python -c 'import pandas, json; print(json.dumps(pandas.read_csv(\"out/traj.csv\").to_dict(orient=\"list\")))'"
+    }
+}
+```
+
+Rules and choices:
+
+- **`id` is mandatory for a wrapper** — it is the key that binds calculators to this
+  model. Match it to the alias file name (`MyCode.json` → `"id": "MyCode"`).
+- Pick `varprefix`/`formulaprefix`/`delim`/`commentline` that do NOT collide with the
+  code's own input syntax (e.g. if `$` is meaningful to the code, use `%`; `commentline`
+  must be the code's real comment character so `#@` context lines are ignored by the code).
+- Each `output` entry is a shell command run **inside the case's result directory** after
+  the run; its stdout is the value, auto-cast to int/float/list/dict when possible. Returning
+  a JSON dict/list (as `trajectory` above) gives structured columns in the results DataFrame.
+- Prefer `python3` over `python` in output commands, and keep dependencies minimal —
+  these commands run on the user's machine, not yours.
+
+## 2. The runner script
+
+The contract (see "Per-case execution lifecycle" in [reference.md](reference.md)):
+
+- invoked **inside a fresh case directory** containing the compiled input file(s);
+- receives the compiled input file (or directory) as **first argument** `$1`;
+- must write the output files that the model's `output` commands parse;
+- exit status `0` = case done, non-zero = case failed (fz retries it elsewhere);
+- stdout/stderr are captured to `out.txt`/`err.txt` automatically — print freely;
+- if the code spawns long-lived subprocesses, write their PID to a `PID` file so
+  interrupts can kill them.
+
+```bash
+#!/bin/bash
+# MyCode.sh — fz runner for MyCode. Usage: MyCode.sh <compiled input file>
+
+# locate the executable: PATH first, then a conventional install dir
+MYCODE=${MYCODE_BIN:-$(command -v mycode || echo /opt/mycode/bin/mycode)}
+[ -x "$MYCODE" ] || { echo "mycode executable not found (set MYCODE_BIN)" >&2; exit 2; }
+
+"$MYCODE" "$1" out &      # mycode <input file> <output dir>
+echo $! >> PID            # let fz kill the run on interrupt
+wait $!
+status=$?
+rm -f PID
+
+# fail loudly if the expected output is missing, so the case is marked "error"
+[ $status -eq 0 ] && [ -f out/results.log ] || exit 1
+```
+
+## 3. The local calculator alias
+
+```json
+{
+    "uri": "sh://",
+    "models": {
+        "MyCode": ".fz/calculators/MyCode.sh"
+    }
+}
+```
+
+`models` maps the model **id** to the command launching it on this machine. With this
+file installed, `fzr --model MyCode ...` without `--calculators` finds and uses it
+automatically. Users add their own `ssh://`/`slurm://` aliases with the same `models` key
+for remote execution.
+
+## 4. Test it like a user would
+
+From a scratch directory:
+
+```bash
+fz install model ./fz-mycode.zip        # or the repo path / URL
+fz list --check --format json           # model + calculator must validate
+
+# then the SKILL.md verification ladder on a sample input:
+fzi --input_path tests/input.txt --model MyCode --format json     # variables found?
+fzc --input_path tests/input.txt --model MyCode \
+    --input_variables '{"x": 1}' --output_dir compiled/           # compiles?
+(cd compiled && bash .fz/calculators/MyCode.sh input.txt)         # runs?
+fzo --output_path compiled/ --model MyCode --format json          # outputs parse?
+fzr --input_path tests/input.txt --model MyCode \
+    --input_variables '{"x": [1, 2]}' --format json               # end to end
+```
+
+Ship that sequence as `tests/test.sh` in the wrapper repo (CI-friendly: it needs only
+fz, bash, and the simulation code).
+
+## 5. Publish
+
+- Name the repo `fz-<code>`; the default branch must be `main` (the installer fetches
+  `archive/refs/heads/main.zip`).
+- README: what the wrapper expects installed (the code itself, env vars like
+  `MYCODE_BIN`), the variables syntax chosen, the outputs provided, and a copy-paste
+  quickstart (`fz install model <code>` + one `fzr` line).
+- Same convention for algorithm packages: `fz-<name>` with `.fz/algorithms/<name>.py`,
+  installed via `fz install algorithm <name>`.
+
+## Existing wrappers to imitate
+
+Browse <https://github.com/orgs/Funz/repositories?q=fz-> — e.g. `fz-modelica` and
+`fz-moret` are reference implementations of this layout (the `plugin-*`/`algorithm-*`
+repos are legacy Java-Funz, different format).

--- a/tests/test_cli_aliases.py
+++ b/tests/test_cli_aliases.py
@@ -85,6 +85,30 @@ class TestFlagAliases:
         assert all(r["status"] == "done" for r in records)
         assert Path("myresults").exists()
 
+    def test_calculators_accepts_bare_alias(self):
+        """--calculators <alias> resolves .fz/calculators/<alias>.json"""
+        _write_input()
+        _write_file("calc.sh", "#!/bin/bash\necho 42 > output.txt\n")
+        Path(".fz/models").mkdir(parents=True)
+        _write_file(".fz/models/pg.json", json.dumps({
+            "id": "pg", "varprefix": "$", "output": {"y": "cat output.txt"},
+        }))
+        Path(".fz/calculators").mkdir(parents=True)
+        _write_file(".fz/calculators/loc.json", json.dumps({
+            "uri": "sh://", "models": {"pg": "bash calc.sh"},
+        }))
+        result = run_fz_cli_function("fzr_main", [
+            "input.txt", "--model", "pg",
+            "--variables", '{"x": [1]}',
+            "--calculators", "loc",
+            "--results", "res_alias",
+            "--format", "json",
+        ])
+        assert result.returncode == 0, result.stderr
+        records = json.loads(result.stdout)
+        assert records[0]["status"] == "done"
+        assert records[0]["y"] == 42
+
     def test_canonical_flags_still_work(self):
         _write_input()
         result = run_fz_cli_function("fzc_main", [

--- a/tests/test_fzd_calculator_discovery.py
+++ b/tests/test_fzd_calculator_discovery.py
@@ -1,0 +1,93 @@
+"""
+Regression tests for calculator alias resolution:
+
+- fzd with calculators omitted must auto-discover installed calculator aliases
+  bound to the model id, exactly like fzr (it used to resolve calculators
+  before reading the model id, producing an empty sh:// command and failing
+  every case).
+- fzr must accept a calculator alias resolved to a dict (the CLI resolves bare
+  alias names to their JSON content; fzr used to reject non-string elements).
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pandas")
+
+import fz
+
+
+ALGORITHM = '''#title: TwoPoints test algorithm
+class TwoPoints:
+    def __init__(self, **options):
+        pass
+
+    def get_initial_design(self, input_vars, output_vars):
+        return [{"x": 0.25}, {"x": 0.75}]
+
+    def get_next_design(self, previous_input_vars, previous_output_values):
+        return []
+
+    def get_analysis(self, input_vars, output_values):
+        return {"text": "ok", "data": {"n": len(output_values)}}
+'''
+
+
+def _write(path, content):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="\n") as f:
+        f.write(content)
+
+
+def _setup_installed_wrapper():
+    """Simulate an installed fz wrapper: model alias + calculator alias + runner"""
+    _write("input.txt", "x=$x\n")
+    _write("calc.sh", "#!/bin/bash\nsource $1\necho \"y = $x\" > output.txt\n")
+    _write(".fz/models/pg.json", json.dumps({
+        "id": "pg",
+        "varprefix": "$",
+        "output": {"y": "grep 'y = ' output.txt | awk '{print $3}'"},
+    }))
+    _write(".fz/calculators/localhost_pg.json", json.dumps({
+        "uri": "sh://",
+        "models": {"pg": "bash calc.sh"},
+    }))
+
+
+def test_fzd_autodiscovers_installed_calculator():
+    """fzd with calculators omitted finds the installed alias for the model"""
+    _setup_installed_wrapper()
+    _write("algo.py", ALGORITHM)
+
+    result = fz.fzd(
+        "input.txt",
+        {"x": "[0;1]"},
+        "pg",
+        output_expression="y",
+        algorithm="algo.py",
+        # calculators intentionally omitted: must auto-discover localhost_pg
+    )
+
+    xy = result["XY"]
+    assert len(xy) == 2
+    assert sorted(xy["x"].tolist()) == [0.25, 0.75]
+    assert sorted(xy["y"].tolist()) == [0.25, 0.75]
+
+
+def test_fzr_accepts_calculator_dict():
+    """fzr accepts an alias resolved to a dict (as the CLI produces)"""
+    _setup_installed_wrapper()
+    calculator_dict = json.loads(Path(".fz/calculators/localhost_pg.json").read_text())
+
+    results = fz.fzr(
+        "input.txt",
+        {"x": [0.5]},
+        "pg",
+        results_dir="results_dict",
+        calculators=[calculator_dict],
+    )
+
+    assert list(results["status"]) == ["done"]
+    assert list(results["y"]) == [0.5]


### PR DESCRIPTION
## Summary

Verifying agent-session feedback (retex) added to the fz skill surfaced two real bugs, both fixed here:

- **`fzd` calculator auto-discovery never worked**: `fzd` resolved calculators *before* reading the model id, so omitting `calculators` auto-discovered nothing, silently ran an empty `sh://` command, and failed every case. It now passes `model_id` to `_resolve_calculators_arg` exactly like `fzr` does.
- **`--calculators <bare-alias>` raised TypeError**: the CLI resolves alias names to their JSON dict, but `fzr`'s argument validation only accepted strings. Validation now accepts dicts (which `_resolve_calculators_arg` always supported downstream).

Also in this PR:

- `fzd` docstring fix (`analysis_dir` default is `"analysis"`, not `"results_fzd"`).
- Skill text updated with version-scoped notes: the fz 1.0 (PyPI) workarounds remain documented, with the fixed behavior noted for newer fz.
- **New `skills/fz/wrapper.md`**: how to implement and publish a reusable `fz-<code>` wrapper — repo layout expected by `fz install model`, model JSON rules (`id` binding), runner script contract (case dir, `$1`, exit status, PID file), localhost calculator alias, user-style test ladder. It is automatically covered by the skill drift tests (which immediately caught two fictional flags in its example — fixed).

## Test plan

- [x] new `tests/test_fzd_calculator_discovery.py`: fzd auto-discovery end to end against a simulated installed wrapper; fzr with a calculator dict
- [x] new CLI test: `fzr --calculators <bare-alias>` resolves `.fz/calculators/<alias>.json`
- [x] skill drift tests pass on all skill files including wrapper.md
- [x] full local suite with CI exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)