### PR TITLE
fix: run fzd function-model calls sequentially, never via a thread pool

### DIFF
--- a/doc/core-functions.md
+++ b/doc/core-functions.md
@@ -533,7 +533,7 @@ result = fz.fzd(
 - `model` (dict, str, or callable): Model definition, alias, or a Python function (see below)
 - `output_expression` (str or None): Expression to evaluate from outputs (e.g., `"pressure"` or `"r1 + r2 * 2"`); may be `None` only when `model` is a callable
 - `algorithm` (str): Path to algorithm Python file
-- `calculators` (str, list, or int): Calculator URI(s) (default: `["sh://"]`); when `model` is a callable, must be an `int` giving the number of parallel calls (default: `1`)
+- `calculators` (str, list, or int): Calculator URI(s) (default: `["sh://"]`); when `model` is a callable, must be an `int` (default: `1`), accepted for API compatibility — calls are always run sequentially, never in parallel (see below)
 - `algorithm_options` (dict, str, or None): Algorithm-specific options (dict, JSON string, or JSON file path)
 - `analysis_dir` (str): Analysis results directory (default: `"analysis"`)
 
@@ -556,13 +556,14 @@ Instead of a file-based model, `model` can be a Python callable. In this mode:
   the function's return value (its return value directly if it's a scalar, the
   first item if it returns a list/tuple, or the first key's value if it
   returns a dict/namedtuple).
-- `calculators` must be an `int`: the number of function calls run in
-  parallel, via a thread pool, within the current Python session (no
-  subprocess/SSH/SLURM calculators involved). With `calculators=1` (the
-  default), calls run sequentially in the calling thread rather than through
-  a thread pool — this matters for model functions that are only safe to
-  call from that thread, such as an embedded interpreter callback (e.g. an R
-  function bridged in via `reticulate`).
+- `calculators` must be an `int` (default `1`), accepted for API
+  compatibility. Function-model calls are always run sequentially, one at a
+  time in the calling thread (like a plain loop), regardless of the value of
+  `calculators` — never through a thread pool. This is required for model
+  functions that are only safe to call from that thread, such as an embedded
+  interpreter callback (e.g. an R function bridged in via `reticulate`), and
+  there is no reliable way to tell those apart from an ordinary thread-safe
+  Python function.
 - `analysis_dir` behaves as usual (`X_N.csv`, `Y_N.csv`, `results_N.html`,
   final analysis), except each iteration's directory (`iterNNN/`) only
   contains a `values.csv` of that iteration's function inputs/outputs — no

--- a/doc/core-functions.md
+++ b/doc/core-functions.md
@@ -558,7 +558,11 @@ Instead of a file-based model, `model` can be a Python callable. In this mode:
   returns a dict/namedtuple).
 - `calculators` must be an `int`: the number of function calls run in
   parallel, via a thread pool, within the current Python session (no
-  subprocess/SSH/SLURM calculators involved).
+  subprocess/SSH/SLURM calculators involved). With `calculators=1` (the
+  default), calls run sequentially in the calling thread rather than through
+  a thread pool — this matters for model functions that are only safe to
+  call from that thread, such as an embedded interpreter callback (e.g. an R
+  function bridged in via `reticulate`).
 - `analysis_dir` behaves as usual (`X_N.csv`, `Y_N.csv`, `results_N.html`,
   final analysis), except each iteration's directory (`iterNNN/`) only
   contains a `values.csv` of that iteration's function inputs/outputs — no

--- a/fz/core.py
+++ b/fz/core.py
@@ -1783,7 +1783,19 @@ def _evaluate_function_model_point(model_func, point, output_expression):
 
 
 def _run_function_model_design(model_func, design_points, output_expression, max_workers):
-    """Evaluate design_points against model_func in parallel; returns list of (output_data, output_value, error)."""
+    """Evaluate design_points against model_func, one at a time, in the calling thread.
+
+    Always sequential (a plain loop, like R's lapply), regardless of
+    max_workers: concurrent.futures.ThreadPoolExecutor always dispatches to a
+    *worker* thread, even with max_workers=1 — never the calling thread. That
+    breaks model_func callables that are only safe to call from the thread
+    that created them, such as an R closure bridged in via reticulate, which
+    crashes the host process if invoked from any thread other than the main
+    one. There is no way to distinguish such callables from an ordinary,
+    thread-safe Python function, so we always run sequentially to stay safe
+    for both. max_workers is accepted for API compatibility but currently has
+    no effect on execution.
+    """
     def _call(point):
         try:
             output_data, output_value = _evaluate_function_model_point(model_func, point, output_expression)
@@ -1791,26 +1803,7 @@ def _run_function_model_design(model_func, design_points, output_expression, max
         except Exception as e:
             return None, None, str(e)
 
-    workers = max(1, int(max_workers) if max_workers else 1)
-
-    if workers == 1:
-        # Run sequentially in the calling thread rather than a thread pool.
-        # ThreadPoolExecutor always dispatches to a *worker* thread, even with
-        # max_workers=1 — never the calling thread. That breaks model_func
-        # callables that are only safe to call from the thread that created
-        # them (e.g. an R closure bridged in via reticulate, which crashes
-        # the host process if invoked from any thread other than the main
-        # one). Since single-worker execution has no parallelism to gain
-        # from a thread pool anyway, call directly instead.
-        return [_call(point) for point in design_points]
-
-    import concurrent.futures
-    results = [None] * len(design_points)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        future_to_index = {executor.submit(_call, point): i for i, point in enumerate(design_points)}
-        for future in concurrent.futures.as_completed(future_to_index):
-            results[future_to_index[future]] = future.result()
-    return results
+    return [_call(point) for point in design_points]
 
 
 def _save_function_model_iteration_csv(iteration_result_dir, all_var_names, unique_design, unique_results):
@@ -1859,8 +1852,12 @@ def fzd(
        - output_expression may be None, in which case the value of the first
          key of the function's return value is used (or the return value
          itself if it's a plain scalar)
-       - calculators must be an int: the number of function calls run in
-         parallel (via a thread pool) within this Python session
+       - calculators must be an int (defaults to 1), accepted for API
+         compatibility; function calls are always run sequentially, one at a
+         time in the calling thread — never via a thread pool. This is
+         required for model callables that are only safe to call from that
+         thread (e.g. an R function bridged in via reticulate), which cannot
+         be reliably distinguished from an ordinary thread-safe function
        - analysis_dir behaves as usual, except the per-iteration directory
          only contains a CSV of the function's inputs/outputs (no case dirs)
 
@@ -1874,8 +1871,9 @@ def fzd(
         calculators: Calculator specifications. If omitted, installed calculator
             aliases supporting the model id are auto-discovered (like fzr);
             falls back to ["sh://"] when none are found.
-            When model is a callable, this must be an int: the number of
-            parallel function calls (defaults to 1).
+            When model is a callable, this must be an int (defaults to 1),
+            accepted for API compatibility but currently has no effect:
+            calls always run sequentially (see above).
         algorithm_options: Algorithm-specific options. Can be:
             - Dict: {"batch_size": 10, "max_iter": 100}
             - JSON string: '{"batch_size": 10, "max_iter": 100}'

--- a/fz/core.py
+++ b/fz/core.py
@@ -1784,11 +1784,7 @@ def _evaluate_function_model_point(model_func, point, output_expression):
 
 def _run_function_model_design(model_func, design_points, output_expression, max_workers):
     """Evaluate design_points against model_func in parallel; returns list of (output_data, output_value, error)."""
-    import concurrent.futures
-
-    results = [None] * len(design_points)
-
-    def _worker(point):
+    def _call(point):
         try:
             output_data, output_value = _evaluate_function_model_point(model_func, point, output_expression)
             return output_data, output_value, None
@@ -1796,8 +1792,22 @@ def _run_function_model_design(model_func, design_points, output_expression, max
             return None, None, str(e)
 
     workers = max(1, int(max_workers) if max_workers else 1)
+
+    if workers == 1:
+        # Run sequentially in the calling thread rather than a thread pool.
+        # ThreadPoolExecutor always dispatches to a *worker* thread, even with
+        # max_workers=1 — never the calling thread. That breaks model_func
+        # callables that are only safe to call from the thread that created
+        # them (e.g. an R closure bridged in via reticulate, which crashes
+        # the host process if invoked from any thread other than the main
+        # one). Since single-worker execution has no parallelism to gain
+        # from a thread pool anyway, call directly instead.
+        return [_call(point) for point in design_points]
+
+    import concurrent.futures
+    results = [None] * len(design_points)
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        future_to_index = {executor.submit(_worker, point): i for i, point in enumerate(design_points)}
+        future_to_index = {executor.submit(_call, point): i for i, point in enumerate(design_points)}
         for future in concurrent.futures.as_completed(future_to_index):
             results[future_to_index[future]] = future.result()
     return results

--- a/skills/fz/reference.md
+++ b/skills/fz/reference.md
@@ -82,8 +82,10 @@ callable as `model` instead of a dict/alias. Then `input_path` must be `None`;
 `input_variables` keys must match the function's parameters; `output_expression`
 may be `None` (defaults to the first value of the function's return — scalar,
 first list/tuple item, or first dict/namedtuple key); `calculators` must be an
-`int` — the number of parallel calls run via a thread pool in-process (no
-sh/ssh/slurm calculators involved). Each iteration's directory then contains
+`int` (default `1`), accepted for API compatibility — calls always run
+sequentially in-process, never in parallel, so the model function is safe to
+call even if it's only usable from the calling thread (e.g. an R function
+bridged in via reticulate). Each iteration's directory then contains
 only a `values.csv` of that iteration's function inputs/outputs (no case dirs).
 
 ### fz.fzl — list and validate models/calculators


### PR DESCRIPTION
## Summary
- `fzd()`'s new direct-Python-function `model` support (cbf5e9d) dispatches calls through `concurrent.futures.ThreadPoolExecutor` whenever `calculators>1`, and even `concurrent.futures.ThreadPoolExecutor(max_workers=1)` always runs tasks in a worker thread, never the calling thread. Model callables that are only safe to invoke from their creating thread — e.g. an R closure bridged in via `reticulate`, used by the `fz.R` wrapper — crash the host process with a stack overflow when called from any other thread. There's no reliable way to detect such callables and tell them apart from an ordinary thread-safe Python function.
- `_run_function_model_design` now always evaluates design points sequentially, one call at a time in the calling thread (a plain loop, equivalent to R's `lapply`), regardless of `calculators`. `calculators` is still accepted as an int for API compatibility but no longer has any effect on execution.
- Docs (`doc/core-functions.md`, `skills/fz/reference.md`) and docstrings updated to describe this.

## Test plan
- [x] `pytest tests/test_fzd.py` — 35 passed
- [x] Verified from R via `reticulate`: an R closure passed as `fzd(model=..., calculators=1L)` and `calculators=4L` both previously crashed the R session; both now complete and return correct results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)