### PR TITLE
Add native Python output extraction (python: expressions and callables) — no shell required

### DIFF
--- a/.github/workflows/shell-free-outputs.yml
+++ b/.github/workflows/shell-free-outputs.yml
@@ -1,10 +1,24 @@
-name: Shell-free outputs (Windows, no bash)
+name: Shell-free outputs (python://, jq://, yq://, xpath://)
 
-# Proves that native Python output extraction ("python:" expressions and
-# callables) works on a bare Windows runner WITHOUT MSYS2, Git-Bash or
-# FZ_SHELL_PATH — unlike the main CI, which installs MSYS2 for the legacy
-# shell-command outputs. Any accidental shell dependency in this code path
-# will fail here.
+# Proves that native output extraction ("python://" expressions/callables,
+# "jq://", "yq://" and "xpath://" filters) works cross-platform, including
+# on Windows, WITHOUT relying on bash — unlike the main CI, which installs
+# MSYS2 for the legacy shell-command ("bash://" / implicit-default)
+# outputs.
+#
+# Note: earlier revisions of this workflow tried to additionally *prove*
+# bash is unreachable, by stripping Git-Bash/MSYS2/Cygwin from PATH on the
+# Windows runner and hard-failing if `bash` was still found. That check
+# turned out to be unreliable on GitHub's windows-latest image (bash stays
+# reachable through paths this doesn't control, e.g. WSL's bash.exe shim),
+# and it isn't actually needed to demonstrate the point of this workflow:
+# the python://, jq://, yq:// and xpath:// code paths never invoke a shell
+# regardless of what happens to be on PATH (they use subprocess without
+# shell=True, or Python's own eval), which is what tests/test_python_outputs.py
+# verifies directly — including the simulated "Windows without bash"
+# scenarios, which monkeypatch platform detection rather than depend on the
+# real environment. So we simply don't set FZ_SHELL_PATH and don't install
+# MSYS2/Git-Bash on Windows here, without trying to force bash's absence.
 
 on:
   push:
@@ -15,7 +29,7 @@ on:
 
 jobs:
   test-shell-free:
-    name: Python outputs on bare ${{ matrix.os }}
+    name: Shell-free outputs on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -32,8 +46,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # Deliberately NO system dependencies step: no MSYS2, no bash, no
-    # coreutils. Only Python packages are installed.
+    # Deliberately no MSYS2/Git-Bash install step: this workflow does not
+    # provision bash. Only Python packages, plus the small set of external
+    # CLI tools needed by jq://, yq:// and xpath:// outputs, are installed.
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
@@ -48,24 +63,44 @@ jobs:
             sys.exit("FZ_SHELL_PATH must not be set for this workflow")
         print("OK: FZ_SHELL_PATH not set")
 
-    - name: Hide Git-Bash from PATH (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
+    # jq is preinstalled on all three GitHub-hosted runner images; this is
+    # a defensive fallback in case that ever changes.
+    - name: Ensure jq is available
+      shell: bash
       run: |
-        # windows-latest ships Git for Windows (which bundles bash.exe).
-        # Remove those directories from PATH so any hidden shell dependency
-        # in the python-output code path fails loudly.
-        $filtered = ($env:PATH -split ';') | Where-Object { $_ -notmatch 'Git' -and $_ -notmatch 'msys' -and $_ -notmatch 'cygwin' }
-        $newPath = $filtered -join ';'
-        Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "jq not found, installing a static release binary"
+          case "${{ runner.os }}" in
+            Linux)   url="https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64" ;;
+            macOS)   url="https://github.com/jqlang/jq/releases/latest/download/jq-macos-amd64" ;;
+            Windows) url="https://github.com/jqlang/jq/releases/latest/download/jq-windows-amd64.exe" ;;
+          esac
+          bin="jq"; [ "${{ runner.os }}" = "Windows" ] && bin="jq.exe"
+          curl -sL -o "$bin" "$url" && chmod +x "$bin"
+          echo "$PWD" >> "$GITHUB_PATH"
+        fi
+        jq --version
 
-    - name: Verify bash is unavailable (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
+    # mikefarah/yq is not preinstalled everywhere; fetch the static binary.
+    - name: Install yq (mikefarah/yq)
+      shell: bash
       run: |
-        $bash = Get-Command bash -ErrorAction SilentlyContinue
-        if ($bash) { Write-Error "bash is still reachable at $($bash.Source)"; exit 1 }
-        Write-Host "OK: bash not reachable"
+        case "${{ runner.os }}" in
+          Linux)   url="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" ;;
+          macOS)   url="https://github.com/mikefarah/yq/releases/latest/download/yq_darwin_amd64" ;;
+          Windows) url="https://github.com/mikefarah/yq/releases/latest/download/yq_windows_amd64.exe" ;;
+        esac
+        bin="yq"; [ "${{ runner.os }}" = "Windows" ] && bin="yq.exe"
+        curl -sL -o "$bin" "$url" && chmod +x "$bin"
+        echo "$PWD" >> "$GITHUB_PATH"
+
+    # xmllint (libxml2) ships by default on ubuntu-latest and macos-latest.
+    # It is not reliably available on windows-latest without MSYS2/Cygwin,
+    # so xpath:// tests self-skip there (requires_xmllint marker) rather
+    # than pulling in a shell-oriented toolchain for this workflow.
+    - name: Check xmllint availability
+      shell: bash
+      run: command -v xmllint && xmllint --version || echo "xmllint not available on this runner; xpath:// tests will skip"
 
     - name: Run shell-free output tests
       run: pytest tests/test_python_outputs.py -v --tb=short

--- a/.github/workflows/shell-free-outputs.yml
+++ b/.github/workflows/shell-free-outputs.yml
@@ -77,7 +77,12 @@ jobs:
           esac
           bin="jq"; [ "${{ runner.os }}" = "Windows" ] && bin="jq.exe"
           curl -sL -o "$bin" "$url" && chmod +x "$bin"
-          echo "$PWD" >> "$GITHUB_PATH"
+          # GITHUB_PATH entries must be in the OS-native path format, since
+          # later steps without an explicit "shell: bash" run under pwsh on
+          # Windows. Git-Bash's "pwd -W" prints the Windows-style path
+          # (e.g. D:/a/fz/fz); plain "pwd" (POSIX style, e.g. /d/a/fz/fz)
+          # would silently fail to resolve for pwsh steps.
+          echo "$(pwd -W 2>/dev/null || pwd)" >> "$GITHUB_PATH"
         fi
         jq --version
 
@@ -92,7 +97,14 @@ jobs:
         esac
         bin="yq"; [ "${{ runner.os }}" = "Windows" ] && bin="yq.exe"
         curl -sL -o "$bin" "$url" && chmod +x "$bin"
-        echo "$PWD" >> "$GITHUB_PATH"
+        # See the jq step above for why "pwd -W" (native Windows path) is
+        # required here instead of plain "pwd" (POSIX-style, e.g. via
+        # Git-Bash on Windows) — GITHUB_PATH is consumed by later pwsh steps.
+        echo "$(pwd -W 2>/dev/null || pwd)" >> "$GITHUB_PATH"
+
+    - name: Verify yq is on PATH
+      shell: bash
+      run: yq --version
 
     # xmllint (libxml2) ships by default on ubuntu-latest and macos-latest.
     # It is not reliably available on windows-latest without MSYS2/Cygwin,

--- a/.github/workflows/shell-free-outputs.yml
+++ b/.github/workflows/shell-free-outputs.yml
@@ -1,0 +1,71 @@
+name: Shell-free outputs (Windows, no bash)
+
+# Proves that native Python output extraction ("python:" expressions and
+# callables) works on a bare Windows runner WITHOUT MSYS2, Git-Bash or
+# FZ_SHELL_PATH — unlike the main CI, which installs MSYS2 for the legacy
+# shell-command outputs. Any accidental shell dependency in this code path
+# will fail here.
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+jobs:
+  test-shell-free:
+    name: Python outputs on bare ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ['3.11']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # Deliberately NO system dependencies step: no MSYS2, no bash, no
+    # coreutils. Only Python packages are installed.
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install pytest h5py
+
+    - name: Ensure FZ_SHELL_PATH is not set
+      shell: python
+      run: |
+        import os, sys
+        if os.environ.get("FZ_SHELL_PATH"):
+            sys.exit("FZ_SHELL_PATH must not be set for this workflow")
+        print("OK: FZ_SHELL_PATH not set")
+
+    - name: Hide Git-Bash from PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        # windows-latest ships Git for Windows (which bundles bash.exe).
+        # Remove those directories from PATH so any hidden shell dependency
+        # in the python-output code path fails loudly.
+        $filtered = ($env:PATH -split ';') | Where-Object { $_ -notmatch 'Git' -and $_ -notmatch 'msys' -and $_ -notmatch 'cygwin' }
+        $newPath = $filtered -join ';'
+        Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
+
+    - name: Verify bash is unavailable (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $bash = Get-Command bash -ErrorAction SilentlyContinue
+        if ($bash) { Write-Error "bash is still reachable at $($bash.Source)"; exit 1 }
+        Write-Host "OK: bash not reachable"
+
+    - name: Run shell-free output tests
+      run: pytest tests/test_python_outputs.py -v --tb=short

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,14 @@
   fully portable on Windows without `FZ_SHELL_PATH`.
 - From the Python API, output values can also be callables receiving the case
   result directory as a `pathlib.Path`.
+- `hdf5_file(path, dataset=None)` helper for HDF5 results (optional `h5py`
+  dependency); values are converted to native Python types.
+- fz is now importable on Windows without bash: the import-time check warns
+  instead of raising. Shell-dependent features (legacy shell-command outputs,
+  `sh://` calculators) raise a helpful error with installation instructions
+  at use time; shell-free workflows need no bash at all. A dedicated CI
+  workflow (`shell-free-outputs.yml`) runs the Python-output tests on a bare
+  Windows runner with Git-Bash removed from PATH.
 - Legacy shell-command outputs are unchanged and can be mixed freely with
   Python outputs in the same model. The `python:` prefix also works with
   `fzo --output-cmd NAME="python: ..."` on the CLI.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,27 +2,45 @@
 
 ## Unreleased
 
-### Native Python output extraction (no shell required)
+### Native shell-free output extraction: python://, jq://, yq://, xpath://
 
 - Model `output` values can now be native Python expressions, marked with the
-  `python:` prefix, e.g. `"pressure": "python: grep(r'pressure = (\S+)', 'output.txt')"`.
+  `python://` prefix, e.g. `"pressure": "python://grep(r'pressure = (\S+)', 'output.txt')"`.
   Expressions are evaluated in the case result directory with built-in helpers
   (`read`, `lines`, `line`, `grep`, `json_file`, `csv_file`) and the `re`,
   `json`, `math`, `statistics`, `np`, `pd` modules — no bash/grep/awk needed,
   fully portable on Windows without `FZ_SHELL_PATH`.
+- New `jq://` output prefix for JSON extraction with the
+  [jq](https://jqlang.org/) command-line tool, e.g.
+  `"energy": "jq://.energy results.json"`. Requires the `jq` executable on
+  `PATH`; no bash/shell otherwise involved.
+- New `yq://` output prefix for YAML (and, via extension auto-detection,
+  JSON/XML/TOML) extraction with the [mikefarah/yq](https://github.com/mikefarah/yq)
+  command-line tool, e.g. `"version": "yq://.metadata.version config.yaml"`.
+  Requires the `yq` executable on `PATH`; no bash/shell otherwise involved.
+- New `xpath://` output prefix for XML extraction with `xmllint --xpath`
+  (libxml2), e.g. `"pressure": "xpath://'//pressure/text()' output.xml"`.
+  Requires the `xmllint` executable on `PATH`; no bash/shell otherwise
+  involved. The matched text is cast to int/float when possible, like `grep`.
+- New `bash://` output prefix to explicitly mark a legacy shell-command
+  output, alongside the implicit default (a plain string with no recognized
+  prefix is still treated as a shell command, unchanged, for backward
+  compatibility). All five forms (`bash://`/implicit, `python://`, `jq://`,
+  `yq://`, `xpath://`, plus Python callables) can be freely mixed in the
+  same model.
 - From the Python API, output values can also be callables receiving the case
   result directory as a `pathlib.Path`.
 - `hdf5_file(path, dataset=None)` helper for HDF5 results (optional `h5py`
   dependency); values are converted to native Python types.
 - fz is now importable on Windows without bash: the import-time check warns
-  instead of raising. Shell-dependent features (legacy shell-command outputs,
-  `sh://` calculators) raise a helpful error with installation instructions
-  at use time; shell-free workflows need no bash at all. A dedicated CI
-  workflow (`shell-free-outputs.yml`) runs the Python-output tests on a bare
-  Windows runner with Git-Bash removed from PATH.
-- Legacy shell-command outputs are unchanged and can be mixed freely with
-  Python outputs in the same model. The `python:` prefix also works with
-  `fzo --output-cmd NAME="python: ..."` on the CLI.
+  instead of raising. Only genuinely shell-dependent features (legacy
+  shell-command outputs, `sh://` calculators) raise a helpful error with
+  installation instructions at use time; shell-free workflows (`python://`,
+  `jq://`, `yq://`, `xpath://`) need no bash at all. A dedicated CI workflow
+  (`shell-free-outputs.yml`) exercises these output kinds cross-platform,
+  including Windows, without provisioning bash.
+- The `python://` prefix also works with `fzo --output-cmd NAME="python://..."`
+  on the CLI (as do `jq://`, `yq://`, `xpath://` and `bash://`).
 
 ## Version 1.1 (2026-06-15)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Native Python output extraction (no shell required)
+
+- Model `output` values can now be native Python expressions, marked with the
+  `python:` prefix, e.g. `"pressure": "python: grep(r'pressure = (\S+)', 'output.txt')"`.
+  Expressions are evaluated in the case result directory with built-in helpers
+  (`read`, `lines`, `line`, `grep`, `json_file`, `csv_file`) and the `re`,
+  `json`, `math`, `statistics`, `np`, `pd` modules — no bash/grep/awk needed,
+  fully portable on Windows without `FZ_SHELL_PATH`.
+- From the Python API, output values can also be callables receiving the case
+  result directory as a `pathlib.Path`.
+- Legacy shell-command outputs are unchanged and can be mixed freely with
+  Python outputs in the same model. The `python:` prefix also works with
+  `fzo --output-cmd NAME="python: ..."` on the CLI.
+
 ## Version 1.1 (2026-06-15)
 
 ### CLI argument aliases (README forms now work)

--- a/README.md
+++ b/README.md
@@ -199,7 +199,13 @@ model = {
     "output": {
         "pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"
         # or, shell-free (portable, no bash/FZ_SHELL_PATH needed):
-        # "pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')"
+        # "pressure": "python://grep(r'pressure = (\\S+)', 'output.txt')"
+        # or, for JSON results, using jq (requires the jq executable):
+        # "pressure": "jq://.pressure output.json"
+        # or, for YAML/JSON/XML/TOML results, using yq (requires yq):
+        # "pressure": "yq://.pressure output.yaml"
+        # or, for XML results, using XPath (requires xmllint):
+        # "pressure": "xpath://'//pressure/text()' output.xml"
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ model = {
     "commentline": "#",
     "output": {
         "pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"
+        # or, shell-free (portable, no bash/FZ_SHELL_PATH needed):
+        # "pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')"
     }
 }
 

--- a/doc/model-definition.md
+++ b/doc/model-definition.md
@@ -150,20 +150,24 @@ model = {
 - Standard shell commands: `grep`, `awk`, `sed`, `cat`, `head`, `tail`
 - Custom scripts: `python extract.py`, `bash parse.sh`
 - Pipes and redirection supported: `grep ... | awk ...`
+- This is the implicit default for any output string without a recognized
+  prefix (see below); it can also be marked explicitly with `bash://`, e.g.
+  `"pressure": "bash://grep 'Pressure:' output.txt | awk '{print $2}'"`.
+  Shell-command outputs require bash (and Unix utilities) on Windows.
 
 **Native Python extraction (no shell required)**:
 
-Output values can also be native Python expressions (prefix `python:`) or,
+Output values can also be native Python expressions (prefix `python://`) or,
 from the Python API, callables. No bash/grep/awk needed — fully portable,
 including on Windows without `FZ_SHELL_PATH`:
 
 ```python
 model = {
     "output": {
-        # "python:" expression, evaluated in the result directory
-        "pressure": "python: grep(r'Pressure: (\\S+)', 'output.txt')",
-        "energy":   "python: json_file('results.json')['energy']",
-        "max_temp": "python: max(csv_file('temps.csv', column='T'))",
+        # "python://" expression, evaluated in the result directory
+        "pressure": "python://grep(r'Pressure: (\\S+)', 'output.txt')",
+        "energy":   "python://json_file('results.json')['energy']",
+        "max_temp": "python://max(csv_file('temps.csv', column='T'))",
         # Callable (Python API only): receives the result directory as a Path
         "T_final":  lambda d: float((d / "final.txt").read_text()),
     }
@@ -179,10 +183,63 @@ resolve against the result directory. `grep` returns the first capture group
 (or whole match), cast to int/float when possible; `all=True` returns every
 match as a list.
 
-The `python:` prefix also works from the CLI:
+The `python://` prefix also works from the CLI:
 
 ```bash
-fzo output/ --model mymodel --output-cmd pressure="python: grep(r'Pressure: (\S+)', 'output.txt')"
+fzo output/ --model mymodel --output-cmd pressure="python://grep(r'Pressure: (\S+)', 'output.txt')"
+```
+
+**JSON extraction with jq (no shell required)**:
+
+Output values can also be [jq](https://jqlang.org/) filters, prefixed with
+`jq://`: a filter followed by the JSON file to read (relative to the result
+directory). This requires the `jq` executable to be installed and on
+`PATH`, but no bash/shell is otherwise involved:
+
+```python
+model = {
+    "output": {
+        "energy": "jq://.energy results.json",
+        "t_max":  "jq://'.temperatures | max' results.json",
+    }
+}
+```
+
+The result is parsed as JSON, so scalars, lists and objects all come back
+as native Python types.
+
+**YAML (or JSON/XML/TOML) extraction with yq (no shell required)**:
+
+Output values can also be [yq](https://github.com/mikefarah/yq) filters
+(the Go-based mikefarah/yq, not the unrelated Python jq-wrapper of the same
+name), prefixed with `yq://`: same syntax as `jq://`, a filter followed by
+the file to read. `yq` auto-detects the input format from the file
+extension, so this also works for JSON, XML and TOML files, not just YAML.
+Requires the `yq` executable on `PATH`; no bash/shell otherwise involved:
+
+```python
+model = {
+    "output": {
+        "version":  "yq://.metadata.version config.yaml",
+        "pressure": "yq://.results.pressure config.yaml",
+    }
+}
+```
+
+**XML extraction with XPath (no shell required)**:
+
+Output values can also be XPath expressions, prefixed with `xpath://`
+(evaluated with `xmllint --xpath`, part of libxml2): an expression followed
+by the XML file to read. Requires the `xmllint` executable on `PATH`; no
+bash/shell otherwise involved. The matched text is cast to int/float when
+possible, like `grep`:
+
+```python
+model = {
+    "output": {
+        "pressure": "xpath://'//result/pressure/text()' output.xml",
+    }
+}
 ```
 
 ### id (optional)

--- a/doc/model-definition.md
+++ b/doc/model-definition.md
@@ -151,6 +151,39 @@ model = {
 - Custom scripts: `python extract.py`, `bash parse.sh`
 - Pipes and redirection supported: `grep ... | awk ...`
 
+**Native Python extraction (no shell required)**:
+
+Output values can also be native Python expressions (prefix `python:`) or,
+from the Python API, callables. No bash/grep/awk needed — fully portable,
+including on Windows without `FZ_SHELL_PATH`:
+
+```python
+model = {
+    "output": {
+        # "python:" expression, evaluated in the result directory
+        "pressure": "python: grep(r'Pressure: (\\S+)', 'output.txt')",
+        "energy":   "python: json_file('results.json')['energy']",
+        "max_temp": "python: max(csv_file('temps.csv', column='T'))",
+        # Callable (Python API only): receives the result directory as a Path
+        "T_final":  lambda d: float((d / "final.txt").read_text()),
+    }
+}
+```
+
+Available helpers in expressions: `read(path)`, `lines(path)`, `line(path, n)`,
+`grep(pattern, path, group=None, all=False, cast=True)`, `json_file(path)`,
+`csv_file(path, column=None)`, plus the modules `re`, `json`, `math`,
+`statistics`, `np` (numpy), `pd` (pandas) and `Path`. All relative paths
+resolve against the result directory. `grep` returns the first capture group
+(or whole match), cast to int/float when possible; `all=True` returns every
+match as a list.
+
+The `python:` prefix also works from the CLI:
+
+```bash
+fzo output/ --model mymodel --output-cmd pressure="python: grep(r'Pressure: (\S+)', 'output.txt')"
+```
+
 ### id (optional)
 
 Unique identifier for the model, useful for documentation and logging.

--- a/doc/model-definition.md
+++ b/doc/model-definition.md
@@ -172,7 +172,8 @@ model = {
 
 Available helpers in expressions: `read(path)`, `lines(path)`, `line(path, n)`,
 `grep(pattern, path, group=None, all=False, cast=True)`, `json_file(path)`,
-`csv_file(path, column=None)`, plus the modules `re`, `json`, `math`,
+`csv_file(path, column=None)`, `hdf5_file(path, dataset=None)` (requires the
+optional `h5py` package), plus the modules `re`, `json`, `math`,
 `statistics`, `np` (numpy), `pd` (pandas) and `Path`. All relative paths
 resolve against the result directory. `grep` returns the first capture group
 (or whole match), cast to int/float when possible; `all=True` returns every

--- a/fz/__init__.py
+++ b/fz/__init__.py
@@ -12,9 +12,11 @@ A Python package for wrapping parametric simulations with support for:
 
 from .core import fzi, fzc, fzo, fzr, fzl, fzd, check_bash_availability_on_windows
 
-# Check bash availability on Windows at import time
-# This ensures users get immediate feedback if bash is not available
-check_bash_availability_on_windows()
+# Check bash availability on Windows at import time (non-strict: warn only).
+# fz remains importable and fully usable for shell-free workflows (native
+# "python:" output expressions, function models); shell-dependent features
+# raise a helpful error at use time instead.
+check_bash_availability_on_windows(strict=False)
 from .logging import (
     set_log_level,
     get_log_level,

--- a/fz/__init__.py
+++ b/fz/__init__.py
@@ -14,8 +14,9 @@ from .core import fzi, fzc, fzo, fzr, fzl, fzd, check_bash_availability_on_windo
 
 # Check bash availability on Windows at import time (non-strict: warn only).
 # fz remains importable and fully usable for shell-free workflows (native
-# "python:" output expressions, function models); shell-dependent features
-# raise a helpful error at use time instead.
+# "python://", "jq://", "yq://" and "xpath://" output expressions, function
+# models); shell-dependent features raise a helpful error at use time
+# instead.
 check_bash_availability_on_windows(strict=False)
 from .logging import (
     set_log_level,

--- a/fz/core.py
+++ b/fz/core.py
@@ -313,17 +313,25 @@ def _parse_argument(arg, alias_type=None):
 # Calculator-related functions imported later where needed
 
 
-def check_bash_availability_on_windows():
+def check_bash_availability_on_windows(strict: bool = True):
     """
     Check if bash is available on Windows.
 
-    On Windows, fz requires bash to be available for running shell commands
-    and evaluating output expressions. This function checks for bash availability
-    in FZ_SHELL_PATH or common installation locations and raises an error with
-    installation instructions if not found.
+    On Windows, fz requires bash for running legacy shell commands and
+    shell-based output expressions. Native Python output extraction
+    ("python:" expressions and callables, see fz/outparsers.py) does NOT
+    require bash. This function checks for bash availability in
+    FZ_SHELL_PATH or common installation locations.
+
+    Args:
+        strict: If True (default), raise a RuntimeError with installation
+            instructions when bash is not found. If False, only log a
+            warning — used at import time so that fz remains usable on
+            Windows without bash for shell-free workflows.
 
     Raises:
-        RuntimeError: If running on Windows and bash is not found
+        RuntimeError: If running on Windows, bash is not found, and strict
+            is True
     """
     if platform.system() != "Windows":
         # Only check on Windows
@@ -367,7 +375,17 @@ def check_bash_availability_on_windows():
             "TIP: Set FZ_SHELL_PATH environment variable to override system PATH and\n"
             "     ensure fz uses the correct bash and utilities.\n"
         )
-        raise RuntimeError(error_msg)
+        if strict:
+            raise RuntimeError(error_msg)
+        log_warning(
+            "Warning: bash is not available on Windows. Legacy shell-command "
+            "output expressions and sh:// calculators will fail; native "
+            "Python outputs ('python:' expressions and callables) remain "
+            "fully functional. See the fz documentation for bash "
+            "installation instructions (MSYS2, Git for Windows, WSL or "
+            "Cygwin) or use FZ_SHELL_PATH."
+        )
+        return
 
     # bash found - log the path for debugging
     log_debug(f"✓ Bash found on Windows: {bash_path}")
@@ -1161,6 +1179,15 @@ def fzo(
 
     model = _resolve_model(model)
     output_spec = model.get("output", {})
+
+    # If any output uses a legacy shell command (not a native Python
+    # expression/callable), bash must be available on Windows. Check once,
+    # at use time, with the full installation instructions.
+    if any(
+        isinstance(spec, str) and not is_python_expression(spec)
+        for spec in output_spec.values()
+    ):
+        check_bash_availability_on_windows(strict=True)
 
     # Resolve output_path as glob pattern (may match multiple directories)
     output_paths = resolve_cache_paths(output_path)

--- a/fz/core.py
+++ b/fz/core.py
@@ -76,6 +76,7 @@ from .helpers import (
     prepare_temp_directories,
 )
 from .shell import run_command, replace_commands_in_string
+from .outparsers import is_python_expression, evaluate_python_output
 from .io import (
     flatten_dict_columns,
     get_analysis,
@@ -1192,6 +1193,14 @@ def fzo(
         output_errors = []  # Collect output parsing errors for this directory
         for key, command in output_spec.items():
             try:
+                # Native Python output extraction: callable, or "python:" expression
+                # (no shell involved — portable across platforms)
+                if callable(command) or is_python_expression(command):
+                    row[key] = evaluate_python_output(
+                        command, output_path_single.absolute()
+                    )
+                    continue
+
                 # Apply shell path resolution to command if FZ_SHELL_PATH is set
                 resolved_command = replace_commands_in_string(command)
 

--- a/fz/core.py
+++ b/fz/core.py
@@ -76,7 +76,17 @@ from .helpers import (
     prepare_temp_directories,
 )
 from .shell import run_command, replace_commands_in_string
-from .outparsers import is_python_expression, evaluate_python_output
+from .outparsers import (
+    is_python_expression,
+    evaluate_python_output,
+    is_jq_expression,
+    evaluate_jq_output,
+    is_yq_expression,
+    evaluate_yq_output,
+    is_xpath_expression,
+    evaluate_xpath_output,
+    strip_bash_prefix,
+)
 from .io import (
     flatten_dict_columns,
     get_analysis,
@@ -317,10 +327,12 @@ def check_bash_availability_on_windows(strict: bool = True):
     """
     Check if bash is available on Windows.
 
-    On Windows, fz requires bash for running legacy shell commands and
-    shell-based output expressions. Native Python output extraction
-    ("python:" expressions and callables, see fz/outparsers.py) does NOT
-    require bash. This function checks for bash availability in
+    On Windows, fz requires bash for running legacy shell commands
+    (implicit default, or explicit "bash://" prefix). Native output
+    extraction via "python://" expressions/callables, "jq://", "yq://" and
+    "xpath://" filters (see fz/outparsers.py) does NOT require bash — each
+    only needs its own executable (jq, yq, xmllint respectively) for the
+    non-Python forms. This function checks for bash availability in
     FZ_SHELL_PATH or common installation locations.
 
     Args:
@@ -379,11 +391,13 @@ def check_bash_availability_on_windows(strict: bool = True):
             raise RuntimeError(error_msg)
         log_warning(
             "Warning: bash is not available on Windows. Legacy shell-command "
-            "output expressions and sh:// calculators will fail; native "
-            "Python outputs ('python:' expressions and callables) remain "
-            "fully functional. See the fz documentation for bash "
-            "installation instructions (MSYS2, Git for Windows, WSL or "
-            "Cygwin) or use FZ_SHELL_PATH."
+            "output expressions (implicit default, or explicit 'bash://' "
+            "prefix) and sh:// calculators will fail; native 'python://' "
+            "outputs (expressions and callables), 'jq://', 'yq://' and "
+            "'xpath://' outputs (each requiring their own executable: jq, "
+            "yq, xmllint) remain fully functional. See the fz documentation "
+            "for bash installation instructions (MSYS2, Git for Windows, "
+            "WSL or Cygwin) or use FZ_SHELL_PATH."
         )
         return
 
@@ -1184,7 +1198,11 @@ def fzo(
     # expression/callable), bash must be available on Windows. Check once,
     # at use time, with the full installation instructions.
     if any(
-        isinstance(spec, str) and not is_python_expression(spec)
+        isinstance(spec, str)
+        and not is_python_expression(spec)
+        and not is_jq_expression(spec)
+        and not is_yq_expression(spec)
+        and not is_xpath_expression(spec)
         for spec in output_spec.values()
     ):
         check_bash_availability_on_windows(strict=True)
@@ -1220,7 +1238,7 @@ def fzo(
         output_errors = []  # Collect output parsing errors for this directory
         for key, command in output_spec.items():
             try:
-                # Native Python output extraction: callable, or "python:" expression
+                # Native Python output extraction: callable, or "python://" expression
                 # (no shell involved — portable across platforms)
                 if callable(command) or is_python_expression(command):
                     row[key] = evaluate_python_output(
@@ -1228,8 +1246,33 @@ def fzo(
                     )
                     continue
 
-                # Apply shell path resolution to command if FZ_SHELL_PATH is set
-                resolved_command = replace_commands_in_string(command)
+                # Native jq output extraction: "jq://" expression (requires the
+                # jq executable, no shell/bash involved)
+                if is_jq_expression(command):
+                    row[key] = evaluate_jq_output(
+                        command, output_path_single.absolute()
+                    )
+                    continue
+
+                # Native yq output extraction: "yq://" expression (requires the
+                # yq executable, no shell/bash involved)
+                if is_yq_expression(command):
+                    row[key] = evaluate_yq_output(
+                        command, output_path_single.absolute()
+                    )
+                    continue
+
+                # Native XPath output extraction: "xpath://" expression
+                # (requires the xmllint executable, no shell/bash involved)
+                if is_xpath_expression(command):
+                    row[key] = evaluate_xpath_output(
+                        command, output_path_single.absolute()
+                    )
+                    continue
+
+                # Legacy shell command, implicit default or explicit "bash://"
+                # prefix. Apply shell path resolution if FZ_SHELL_PATH is set.
+                resolved_command = replace_commands_in_string(strip_bash_prefix(command))
 
                 # Execute shell command from the matched output directory
                 result = run_command(

--- a/fz/helpers.py
+++ b/fz/helpers.py
@@ -306,9 +306,10 @@ def _validate_model(model: Dict) -> None:
                 raise TypeError(f"Model output keys must be strings, got {type(key).__name__}")
             if not isinstance(value, str) and not callable(value):
                 raise TypeError(
-                    f"Model output values must be strings (shell command or "
-                    f"'python:' expression) or callables, got "
-                    f"{type(value).__name__} for key '{key}'"
+                    f"Model output values must be strings (shell command, "
+                    f"optionally prefixed with 'bash://', or a 'python://', "
+                    f"'jq://', 'yq://' or 'xpath://' expression) or "
+                    f"callables, got {type(value).__name__} for key '{key}'"
                 )
 
     # Validate interpreter if present

--- a/fz/helpers.py
+++ b/fz/helpers.py
@@ -304,8 +304,12 @@ def _validate_model(model: Dict) -> None:
         for key, value in output.items():
             if not isinstance(key, str):
                 raise TypeError(f"Model output keys must be strings, got {type(key).__name__}")
-            if not isinstance(value, str):
-                raise TypeError(f"Model output values must be strings, got {type(value).__name__} for key '{key}'")
+            if not isinstance(value, str) and not callable(value):
+                raise TypeError(
+                    f"Model output values must be strings (shell command or "
+                    f"'python:' expression) or callables, got "
+                    f"{type(value).__name__} for key '{key}'"
+                )
 
     # Validate interpreter if present
     if "interpreter" in model and model["interpreter"] is not None:

--- a/fz/outparsers.py
+++ b/fz/outparsers.py
@@ -1,28 +1,74 @@
 """
-Native Python output extraction for fz models.
+Native output extraction for fz models.
 
-This module allows model "output" entries to be evaluated as Python
-expressions (or callables) instead of shell command pipelines, removing the
-dependency on external tools like grep/awk/sed and making output extraction
-fully portable across platforms (no bash / FZ_SHELL_PATH required).
+This module allows model "output" entries to be evaluated by an extraction
+engine other than a shell pipeline, removing (for the ``python://``,
+``jq://``, ``yq://`` and ``xpath://`` forms) the dependency on bash and
+making output extraction portable across platforms (no bash / FZ_SHELL_PATH
+required).
 
-Three forms are supported for the values of ``model["output"]``:
+Six forms are supported for the values of ``model["output"]``:
 
-1. Shell command string (legacy, unchanged)::
+1. Shell command string, implicit default (legacy, unchanged) or explicitly
+   marked with the ``bash://`` prefix::
 
        {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
+       {"pressure": "bash://grep 'pressure = ' output.txt | awk '{print $3}'"}
 
-2. Python expression string, marked with the ``python:`` prefix::
+   Both lines above are equivalent: a plain string with no recognized
+   prefix is treated as a shell command for backward compatibility. The
+   ``bash://`` prefix lets you say so explicitly, alongside the other
+   prefixed forms in the same model. Shell-command outputs require bash
+   (and Unix utilities) to be available, including on Windows.
 
-       {"pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')"}
+2. Python expression string, marked with the ``python://`` prefix::
+
+       {"pressure": "python://grep(r'pressure = (\\S+)', 'output.txt')"}
 
    The expression is evaluated with the case output directory as base
    directory. A small set of helper functions is available in the
    expression namespace (see :func:`make_helpers`), plus the ``re``,
    ``json``, ``math``, ``statistics`` modules, ``Path``, and — when
-   installed — ``np`` (numpy) and ``pd`` (pandas).
+   installed — ``np`` (numpy) and ``pd`` (pandas). No shell is involved.
 
-3. Python callable (Python API only). The callable receives the case output
+3. jq expression string, marked with the ``jq://`` prefix, for extracting
+   JSON values with the jq command-line tool (https://jqlang.org/)::
+
+       {"energy": "jq://.energy results.json"}
+
+   The part after the prefix is a jq filter followed by the file to read
+   (relative to the case output directory), parsed like a shell command
+   line (so quoting the filter is optional but allowed). The ``jq``
+   executable must be installed and available on ``PATH``; no bash/shell
+   is otherwise required.
+
+4. yq expression string, marked with the ``yq://`` prefix, for extracting
+   values from YAML (and, since yq auto-detects by extension, JSON, XML or
+   TOML) with the mikefarah/yq command-line tool
+   (https://github.com/mikefarah/yq)::
+
+       {"version": "yq://.metadata.version config.yaml"}
+
+   Same syntax as ``jq://`` (filter then file, shell-style parsed). The
+   ``yq`` executable must be installed and available on ``PATH``; no
+   bash/shell is otherwise required. Note: this refers to the Go-based
+   mikefarah/yq (the ``jq``-like YAML processor); the unrelated
+   Python-based kislyuk/yq package uses different flags and is not what
+   this prefix targets.
+
+5. XPath expression string, marked with the ``xpath://`` prefix, for
+   extracting values from XML files with ``xmllint --xpath``
+   (part of libxml2, https://gitlab.gnome.org/GNOME/libxml2)::
+
+       {"pressure": "xpath://'//result/pressure/text()' output.xml"}
+
+   Same syntax as ``jq://`` (expression then file, shell-style parsed).
+   The ``xmllint`` executable must be installed and available on ``PATH``;
+   no bash/shell is otherwise required. The result is the raw text matched
+   by the XPath expression, cast to int/float when possible (like
+   :func:`grep`'s default casting).
+
+6. Python callable (Python API only). The callable receives the case output
    directory as a ``pathlib.Path`` and returns the parsed value::
 
        {"pressure": lambda d: float((d / "pressure.txt").read_text())}
@@ -36,26 +82,121 @@ authored by the user. Do not evaluate model files from untrusted sources.
 import json as _json
 import math as _math
 import re as _re
+import shlex as _shlex
+import shutil as _shutil
 import statistics as _statistics
+import subprocess as _subprocess
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
 from .logging import log_debug
 
 #: Prefix marking a model output entry as a native Python expression
-PYTHON_OUTPUT_PREFIX = "python:"
+PYTHON_OUTPUT_PREFIX = "python://"
+
+#: Prefix marking a model output entry as a jq filter (requires the ``jq``
+#: executable to be installed on the system)
+JQ_OUTPUT_PREFIX = "jq://"
+
+#: Prefix marking a model output entry as a yq filter (requires the
+#: mikefarah/yq executable to be installed on the system)
+YQ_OUTPUT_PREFIX = "yq://"
+
+#: Prefix marking a model output entry as an XPath expression (requires the
+#: ``xmllint`` executable, from libxml2, to be installed on the system)
+XPATH_OUTPUT_PREFIX = "xpath://"
+
+#: Prefix explicitly marking a model output entry as a shell command. This
+#: is the implicit default for any output string without a recognized
+#: prefix, kept for backward compatibility; ``bash://`` lets you say so
+#: explicitly when mixing output kinds in the same model.
+BASH_OUTPUT_PREFIX = "bash://"
 
 
 def is_python_expression(spec: Any) -> bool:
-    """Return True if an output spec string is a Python expression."""
+    """Return True if an output spec string is a ``python://`` expression."""
     return isinstance(spec, str) and spec.lstrip().lower().startswith(
         PYTHON_OUTPUT_PREFIX
     )
 
 
 def strip_python_prefix(spec: str) -> str:
-    """Remove the ``python:`` prefix from an output spec string."""
+    """Remove the ``python://`` prefix from an output spec string."""
     return spec.lstrip()[len(PYTHON_OUTPUT_PREFIX):].strip()
+
+
+def is_jq_expression(spec: Any) -> bool:
+    """Return True if an output spec string is a ``jq://`` filter."""
+    return isinstance(spec, str) and spec.lstrip().lower().startswith(
+        JQ_OUTPUT_PREFIX
+    )
+
+
+def strip_jq_prefix(spec: str) -> str:
+    """Remove the ``jq://`` prefix from an output spec string."""
+    return spec.lstrip()[len(JQ_OUTPUT_PREFIX):].strip()
+
+
+def is_yq_expression(spec: Any) -> bool:
+    """Return True if an output spec string is a ``yq://`` filter."""
+    return isinstance(spec, str) and spec.lstrip().lower().startswith(
+        YQ_OUTPUT_PREFIX
+    )
+
+
+def strip_yq_prefix(spec: str) -> str:
+    """Remove the ``yq://`` prefix from an output spec string."""
+    return spec.lstrip()[len(YQ_OUTPUT_PREFIX):].strip()
+
+
+def is_xpath_expression(spec: Any) -> bool:
+    """Return True if an output spec string is an ``xpath://`` expression."""
+    return isinstance(spec, str) and spec.lstrip().lower().startswith(
+        XPATH_OUTPUT_PREFIX
+    )
+
+
+def strip_xpath_prefix(spec: str) -> str:
+    """Remove the ``xpath://`` prefix from an output spec string."""
+    return spec.lstrip()[len(XPATH_OUTPUT_PREFIX):].strip()
+
+
+def is_bash_expression(spec: Any) -> bool:
+    """
+    Return True if an output spec string is a shell command: either
+    explicitly marked with ``bash://``, or a plain string with no
+    recognized prefix (the implicit legacy default).
+    """
+    if not isinstance(spec, str):
+        return False
+    if (
+        is_python_expression(spec)
+        or is_jq_expression(spec)
+        or is_yq_expression(spec)
+        or is_xpath_expression(spec)
+    ):
+        return False
+    return True
+
+
+def strip_bash_prefix(spec: str) -> str:
+    """Remove an explicit ``bash://`` prefix, if present, from a spec string."""
+    stripped = spec.lstrip()
+    if stripped.lower().startswith(BASH_OUTPUT_PREFIX):
+        return stripped[len(BASH_OUTPUT_PREFIX):].strip()
+    return spec
+
+
+def _cast_numeric(value: str) -> Any:
+    """Cast a string to int/float when possible, otherwise return it as-is."""
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
 
 
 def make_helpers(base_dir: Union[str, Path]) -> Dict[str, Any]:
@@ -122,16 +263,7 @@ def make_helpers(base_dir: Union[str, Path]) -> Dict[str, Any]:
             group = 1 if regex.groups >= 1 else 0
 
         def _cast(value: str) -> Any:
-            if not cast:
-                return value
-            try:
-                return int(value)
-            except ValueError:
-                pass
-            try:
-                return float(value)
-            except ValueError:
-                return value
+            return _cast_numeric(value) if cast else value
 
         if all:
             return [_cast(m.group(group)) for m in regex.finditer(content)]
@@ -275,3 +407,186 @@ def evaluate_python_output(
         pass
 
     return value
+
+
+def evaluate_jq_output(
+    spec: str,
+    output_dir: Union[str, Path],
+) -> Any:
+    """
+    Evaluate a ``jq://`` output spec for one case output directory using the
+    system ``jq`` executable.
+
+    Args:
+        spec: A ``jq://``-prefixed spec string, or a bare ``"<filter> <file>"``
+            string (prefix already stripped). The filter and file are parsed
+            shell-style (``shlex``), so quoting the filter is optional but
+            allowed, e.g. ``"jq://.energy results.json"`` or
+            ``"jq://'.a.b[0]' results.json"``. The file is resolved relative
+            to the case output directory.
+        output_dir: The case output directory.
+
+    Returns:
+        The JSON value produced by ``jq``, decoded to native Python types
+        (str/int/float/bool/None/list/dict) via ``json.loads`` of jq's
+        (non-raw) output.
+
+    Raises:
+        RuntimeError: If the ``jq`` executable is not found on PATH.
+        ValueError: If the spec does not include both a filter and a file.
+        subprocess.CalledProcessError: If ``jq`` exits with a non-zero
+            status (e.g. invalid filter or malformed JSON input).
+    """
+    if _shutil.which("jq") is None:
+        raise RuntimeError(
+            "The 'jq://' output prefix requires the 'jq' executable to be "
+            "installed and available on PATH. See https://jqlang.org/download/ "
+            "for installation instructions."
+        )
+
+    out_dir = Path(output_dir)
+    expr = strip_jq_prefix(spec) if is_jq_expression(spec) else spec
+    tokens = _shlex.split(expr)
+    if len(tokens) < 2:
+        raise ValueError(
+            "Invalid 'jq://' output spec: expected a filter followed by a "
+            f"file, got {spec!r}"
+        )
+    jq_filter, file_arg = tokens[0], tokens[-1]
+    file_path = Path(file_arg)
+    if not file_path.is_absolute():
+        file_path = out_dir / file_path
+
+    log_debug(f"Evaluating jq output filter: {jq_filter} on {file_path}")
+    result = _subprocess.run(
+        ["jq", jq_filter, str(file_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise _subprocess.CalledProcessError(
+            result.returncode, ["jq", jq_filter, str(file_path)],
+            output=result.stdout, stderr=result.stderr,
+        )
+
+    return _json.loads(result.stdout.strip())
+
+
+def evaluate_yq_output(
+    spec: str,
+    output_dir: Union[str, Path],
+) -> Any:
+    """
+    Evaluate a ``yq://`` output spec for one case output directory using the
+    system ``yq`` executable (mikefarah/yq — a jq-like processor for YAML,
+    and, via extension auto-detection, JSON/XML/TOML too).
+
+    Args:
+        spec: A ``yq://``-prefixed spec string, or a bare ``"<filter> <file>"``
+            string (prefix already stripped). Same shell-style parsing as
+            :func:`evaluate_jq_output`, e.g. ``"yq://.metadata.version
+            config.yaml"``. The file is resolved relative to the case
+            output directory.
+        output_dir: The case output directory.
+
+    Returns:
+        The value produced by ``yq`` (invoked with ``-o=json`` for a
+        consistent, unambiguous result), decoded to native Python types via
+        ``json.loads``.
+
+    Raises:
+        RuntimeError: If the ``yq`` executable is not found on PATH.
+        ValueError: If the spec does not include both a filter and a file.
+        subprocess.CalledProcessError: If ``yq`` exits with a non-zero
+            status (e.g. invalid filter or malformed input).
+    """
+    if _shutil.which("yq") is None:
+        raise RuntimeError(
+            "The 'yq://' output prefix requires the 'yq' executable "
+            "(mikefarah/yq) to be installed and available on PATH. See "
+            "https://github.com/mikefarah/yq#install for installation "
+            "instructions."
+        )
+
+    out_dir = Path(output_dir)
+    expr = strip_yq_prefix(spec) if is_yq_expression(spec) else spec
+    tokens = _shlex.split(expr)
+    if len(tokens) < 2:
+        raise ValueError(
+            "Invalid 'yq://' output spec: expected a filter followed by a "
+            f"file, got {spec!r}"
+        )
+    yq_filter, file_arg = tokens[0], tokens[-1]
+    file_path = Path(file_arg)
+    if not file_path.is_absolute():
+        file_path = out_dir / file_path
+
+    log_debug(f"Evaluating yq output filter: {yq_filter} on {file_path}")
+    cmd = ["yq", "-o=json", yq_filter, str(file_path)]
+    result = _subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise _subprocess.CalledProcessError(
+            result.returncode, cmd, output=result.stdout, stderr=result.stderr,
+        )
+
+    return _json.loads(result.stdout.strip())
+
+
+def evaluate_xpath_output(
+    spec: str,
+    output_dir: Union[str, Path],
+) -> Any:
+    """
+    Evaluate an ``xpath://`` output spec for one case output directory using
+    the system ``xmllint`` executable (``xmllint --xpath``, part of
+    libxml2).
+
+    Args:
+        spec: An ``xpath://``-prefixed spec string, or a bare
+            ``"<expression> <file>"`` string (prefix already stripped).
+            Same shell-style parsing as :func:`evaluate_jq_output`, e.g.
+            ``"xpath://'//result/pressure/text()' output.xml"``. The file
+            is resolved relative to the case output directory.
+        output_dir: The case output directory.
+
+    Returns:
+        The raw text matched by the XPath expression, cast to int/float
+        when possible (same casting as :func:`grep`'s default), otherwise
+        returned as a string.
+
+    Raises:
+        RuntimeError: If the ``xmllint`` executable is not found on PATH.
+        ValueError: If the spec does not include both an expression and a
+            file.
+        subprocess.CalledProcessError: If ``xmllint`` exits with a
+            non-zero status (e.g. invalid expression, no match, or
+            malformed XML).
+    """
+    if _shutil.which("xmllint") is None:
+        raise RuntimeError(
+            "The 'xpath://' output prefix requires the 'xmllint' "
+            "executable (libxml2) to be installed and available on PATH."
+        )
+
+    out_dir = Path(output_dir)
+    expr = strip_xpath_prefix(spec) if is_xpath_expression(spec) else spec
+    tokens = _shlex.split(expr)
+    if len(tokens) < 2:
+        raise ValueError(
+            "Invalid 'xpath://' output spec: expected an XPath expression "
+            f"followed by a file, got {spec!r}"
+        )
+    xpath_expr, file_arg = tokens[0], tokens[-1]
+    file_path = Path(file_arg)
+    if not file_path.is_absolute():
+        file_path = out_dir / file_path
+
+    log_debug(f"Evaluating xpath output expression: {xpath_expr} on {file_path}")
+    cmd = ["xmllint", "--xpath", xpath_expr, str(file_path)]
+    result = _subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise _subprocess.CalledProcessError(
+            result.returncode, cmd, output=result.stdout, stderr=result.stderr,
+        )
+
+    return _cast_numeric(result.stdout.strip())

--- a/fz/outparsers.py
+++ b/fz/outparsers.py
@@ -156,6 +156,48 @@ def make_helpers(base_dir: Union[str, Path]) -> Dict[str, Any]:
             return df[column].tolist()
         return df
 
+    def hdf5_file(path: Union[str, Path], dataset: Optional[str] = None) -> Any:
+        """
+        Read a dataset from an HDF5 file (requires the optional ``h5py``
+        dependency: ``pip install h5py``).
+
+        Args:
+            path: HDF5 file, relative to the case output directory.
+            dataset: Dataset name or path within the file (e.g.
+                ``"results/temperature"``). When omitted, returns the list of
+                top-level keys, which is convenient for exploration.
+
+        Returns:
+            The dataset content converted to native Python types (scalars,
+            lists, str) for clean DataFrame/JSON round-trips, or the list of
+            top-level keys when ``dataset`` is None.
+        """
+        try:
+            import h5py
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "The hdf5_file() output helper requires the optional 'h5py' "
+                "package: pip install h5py"
+            ) from exc
+
+        with h5py.File(_resolve(path), "r") as f:
+            if dataset is None:
+                return list(f.keys())
+            data = f[dataset][()]
+
+        # Convert to native Python types
+        import numpy as np
+
+        if isinstance(data, np.ndarray):
+            data = data.tolist()
+        elif isinstance(data, np.generic):
+            data = data.item()
+        if isinstance(data, bytes):
+            data = data.decode()
+        elif isinstance(data, list):
+            data = [d.decode() if isinstance(d, bytes) else d for d in data]
+        return data
+
     helpers: Dict[str, Any] = {
         # helper functions
         "read": read,
@@ -164,6 +206,7 @@ def make_helpers(base_dir: Union[str, Path]) -> Dict[str, Any]:
         "grep": grep,
         "json_file": json_file,
         "csv_file": csv_file,
+        "hdf5_file": hdf5_file,
         # convenient modules / names
         "re": _re,
         "json": _json,

--- a/fz/outparsers.py
+++ b/fz/outparsers.py
@@ -1,0 +1,234 @@
+"""
+Native Python output extraction for fz models.
+
+This module allows model "output" entries to be evaluated as Python
+expressions (or callables) instead of shell command pipelines, removing the
+dependency on external tools like grep/awk/sed and making output extraction
+fully portable across platforms (no bash / FZ_SHELL_PATH required).
+
+Three forms are supported for the values of ``model["output"]``:
+
+1. Shell command string (legacy, unchanged)::
+
+       {"pressure": "grep 'pressure = ' output.txt | awk '{print $3}'"}
+
+2. Python expression string, marked with the ``python:`` prefix::
+
+       {"pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')"}
+
+   The expression is evaluated with the case output directory as base
+   directory. A small set of helper functions is available in the
+   expression namespace (see :func:`make_helpers`), plus the ``re``,
+   ``json``, ``math``, ``statistics`` modules, ``Path``, and — when
+   installed — ``np`` (numpy) and ``pd`` (pandas).
+
+3. Python callable (Python API only). The callable receives the case output
+   directory as a ``pathlib.Path`` and returns the parsed value::
+
+       {"pressure": lambda d: float((d / "pressure.txt").read_text())}
+
+Security note: Python expressions are evaluated with ``eval`` in a dedicated
+namespace. This is the same trust model as the legacy shell commands, which
+are executed verbatim in a shell: the model definition is trusted content
+authored by the user. Do not evaluate model files from untrusted sources.
+"""
+
+import json as _json
+import math as _math
+import re as _re
+import statistics as _statistics
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Union
+
+from .logging import log_debug
+
+#: Prefix marking a model output entry as a native Python expression
+PYTHON_OUTPUT_PREFIX = "python:"
+
+
+def is_python_expression(spec: Any) -> bool:
+    """Return True if an output spec string is a Python expression."""
+    return isinstance(spec, str) and spec.lstrip().lower().startswith(
+        PYTHON_OUTPUT_PREFIX
+    )
+
+
+def strip_python_prefix(spec: str) -> str:
+    """Remove the ``python:`` prefix from an output spec string."""
+    return spec.lstrip()[len(PYTHON_OUTPUT_PREFIX):].strip()
+
+
+def make_helpers(base_dir: Union[str, Path]) -> Dict[str, Any]:
+    """
+    Build the helper namespace available to Python output expressions.
+
+    All path arguments accepted by the helpers are resolved relative to
+    ``base_dir`` (the case output directory), so expressions behave like the
+    legacy shell commands which run with cwd set to that directory.
+
+    Helpers:
+        read(path)                  -> file content as str
+        lines(path)                 -> list of lines (no trailing newlines)
+        line(path, n)               -> n-th line (0-based; negative from end)
+        grep(pattern, path, ...)    -> regex extraction (see docstring)
+        json_file(path)             -> parsed JSON content
+        csv_file(path, column=None) -> pandas DataFrame, or column as list
+    """
+    base = Path(base_dir)
+
+    def _resolve(path: Union[str, Path]) -> Path:
+        p = Path(path)
+        return p if p.is_absolute() else (base / p)
+
+    def read(path: Union[str, Path]) -> str:
+        """Return the full content of a file as a string."""
+        return _resolve(path).read_text()
+
+    def lines(path: Union[str, Path]) -> list:
+        """Return the list of lines of a file (without line endings)."""
+        return read(path).splitlines()
+
+    def line(path: Union[str, Path], n: int) -> str:
+        """Return the n-th line of a file (0-based, negative from end)."""
+        return lines(path)[n]
+
+    def grep(
+        pattern: str,
+        path: Union[str, Path],
+        group: Optional[int] = None,
+        all: bool = False,
+        cast: bool = True,
+    ) -> Any:
+        """
+        Extract values from a file with a regular expression.
+
+        Args:
+            pattern: Regular expression. If it contains capture groups, the
+                first group is returned by default; otherwise the whole match.
+            path: File to search, relative to the case output directory.
+            group: Explicit group index to return (overrides the default).
+            all: If True, return the list of all matches; otherwise the first.
+            cast: If True (default), cast numeric-looking results to
+                int/float.
+
+        Returns:
+            The matched value (or list of values with ``all=True``), or None
+            if no match is found.
+        """
+        regex = _re.compile(pattern, _re.MULTILINE)
+        content = read(path)
+
+        if group is None:
+            group = 1 if regex.groups >= 1 else 0
+
+        def _cast(value: str) -> Any:
+            if not cast:
+                return value
+            try:
+                return int(value)
+            except ValueError:
+                pass
+            try:
+                return float(value)
+            except ValueError:
+                return value
+
+        if all:
+            return [_cast(m.group(group)) for m in regex.finditer(content)]
+        match = regex.search(content)
+        return _cast(match.group(group)) if match else None
+
+    def json_file(path: Union[str, Path]) -> Any:
+        """Parse a JSON file and return its content."""
+        return _json.loads(read(path))
+
+    def csv_file(path: Union[str, Path], column: Optional[str] = None) -> Any:
+        """
+        Load a CSV file with pandas.
+
+        Returns the DataFrame, or the given column as a plain list when
+        ``column`` is provided.
+        """
+        import pandas as pd  # fz already depends on pandas
+
+        df = pd.read_csv(_resolve(path))
+        if column is not None:
+            return df[column].tolist()
+        return df
+
+    helpers: Dict[str, Any] = {
+        # helper functions
+        "read": read,
+        "lines": lines,
+        "line": line,
+        "grep": grep,
+        "json_file": json_file,
+        "csv_file": csv_file,
+        # convenient modules / names
+        "re": _re,
+        "json": _json,
+        "math": _math,
+        "statistics": _statistics,
+        "Path": Path,
+        "base_dir": base,
+    }
+
+    # Optional scientific stack (numpy ships with pandas, but stay defensive)
+    try:
+        import numpy as np
+
+        helpers["np"] = np
+    except ImportError:  # pragma: no cover
+        pass
+    try:
+        import pandas as pd
+
+        helpers["pd"] = pd
+    except ImportError:  # pragma: no cover
+        pass
+
+    return helpers
+
+
+def evaluate_python_output(
+    spec: Union[str, Callable[[Path], Any]],
+    output_dir: Union[str, Path],
+) -> Any:
+    """
+    Evaluate a native Python output spec for one case output directory.
+
+    Args:
+        spec: Either a ``python:``-prefixed expression string, a bare
+            expression string (prefix already stripped), or a callable taking
+            the output directory Path.
+        output_dir: The case output directory.
+
+    Returns:
+        The extracted value (any Python type; numpy scalars are converted to
+        native Python types for clean DataFrame/JSON round-trips).
+
+    Raises:
+        Exception: Propagates any error raised by the expression/callable;
+            the caller is responsible for error reporting (consistent with
+            legacy shell command handling in fzo).
+    """
+    out_dir = Path(output_dir)
+
+    if callable(spec):
+        value = spec(out_dir)
+    else:
+        expr = strip_python_prefix(spec) if is_python_expression(spec) else spec
+        namespace = make_helpers(out_dir)
+        log_debug(f"Evaluating python output expression: {expr}")
+        value = eval(expr, {"__builtins__": __builtins__}, namespace)
+
+    # Normalize numpy scalar types to native Python for consistency
+    try:
+        import numpy as np
+
+        if isinstance(value, np.generic):
+            value = value.item()
+    except ImportError:  # pragma: no cover
+        pass
+
+    return value

--- a/skills/fz/SKILL.md
+++ b/skills/fz/SKILL.md
@@ -133,7 +133,8 @@ with `python:` are evaluated as Python expressions in the result directory (no b
 locale or quoting pitfalls, portable to Windows). Helpers available: `read(path)`,
 `lines(path)`, `line(path, n)`, `grep(pattern, path, all=False)` (returns first capture
 group, cast to number when possible), `json_file(path)`, `csv_file(path, column=None)`,
-plus `re`, `json`, `math`, `statistics`, `np`, `pd`, `Path`:
+`hdf5_file(path, dataset=None)` (optional `h5py` dependency), plus `re`, `json`,
+`math`, `statistics`, `np`, `pd`, `Path`:
 
 ```python
 "output": {

--- a/skills/fz/SKILL.md
+++ b/skills/fz/SKILL.md
@@ -128,8 +128,8 @@ Output command results are auto-cast to Python literals (int, float, list, dict)
 possible. For reusability, save as `.fz/models/perfectgas.json` (project) or
 `~/.fz/models/perfectgas.json` (global) and refer to it by alias: `model="perfectgas"`.
 
-**Prefer shell-free native Python outputs** when authoring new models: values prefixed
-with `python:` are evaluated as Python expressions in the result directory (no bash, no
+**Prefer shell-free native outputs** when authoring new models: values prefixed with
+`python://` are evaluated as Python expressions in the result directory (no bash, no
 locale or quoting pitfalls, portable to Windows). Helpers available: `read(path)`,
 `lines(path)`, `line(path, n)`, `grep(pattern, path, all=False)` (returns first capture
 group, cast to number when possible), `json_file(path)`, `csv_file(path, column=None)`,
@@ -138,14 +138,21 @@ group, cast to number when possible), `json_file(path)`, `csv_file(path, column=
 
 ```python
 "output": {
-    "pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')",
-    "T_max":    "python: max(csv_file('temps.csv', column='T'))"
+    "pressure": "python://grep(r'pressure = (\\S+)', 'output.txt')",
+    "T_max":    "python://max(csv_file('temps.csv', column='T'))"
 }
 ```
 
+For JSON results, `jq://` filters are also shell-free-ish: they only require the `jq`
+executable (no bash), e.g. `"pressure": "jq://.pressure output.json"`. Same idea for
+YAML/JSON/XML/TOML with `yq://` (requires `yq`, mikefarah/yq), e.g.
+`"version": "yq://.metadata.version config.yaml"`, and for XML with `xpath://`
+(requires `xmllint`), e.g. `"pressure": "xpath://'//pressure/text()' output.xml"`.
+
 From the Python API, an output value can also be a callable taking the result directory
-as a `pathlib.Path`. Shell-command strings remain fully supported and can be mixed with
-Python outputs in the same model.
+as a `pathlib.Path`. Legacy shell-command strings remain fully supported (implicit
+default, or explicit `bash://` prefix) and can be mixed with `python://`/`jq://` outputs
+in the same model.
 
 > **A model never says how to *run* the code.** It declares only the input syntax and the
 > output parsers. *Where and how* the simulation executes is the calculator's job (see

--- a/skills/fz/SKILL.md
+++ b/skills/fz/SKILL.md
@@ -128,6 +128,24 @@ Output command results are auto-cast to Python literals (int, float, list, dict)
 possible. For reusability, save as `.fz/models/perfectgas.json` (project) or
 `~/.fz/models/perfectgas.json` (global) and refer to it by alias: `model="perfectgas"`.
 
+**Prefer shell-free native Python outputs** when authoring new models: values prefixed
+with `python:` are evaluated as Python expressions in the result directory (no bash, no
+locale or quoting pitfalls, portable to Windows). Helpers available: `read(path)`,
+`lines(path)`, `line(path, n)`, `grep(pattern, path, all=False)` (returns first capture
+group, cast to number when possible), `json_file(path)`, `csv_file(path, column=None)`,
+plus `re`, `json`, `math`, `statistics`, `np`, `pd`, `Path`:
+
+```python
+"output": {
+    "pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')",
+    "T_max":    "python: max(csv_file('temps.csv', column='T'))"
+}
+```
+
+From the Python API, an output value can also be a callable taking the result directory
+as a `pathlib.Path`. Shell-command strings remain fully supported and can be mixed with
+Python outputs in the same model.
+
 > **A model never says how to *run* the code.** It declares only the input syntax and the
 > output parsers. *Where and how* the simulation executes is the calculator's job (see
 > "Calculators" below). There is no `run` field in a model. If you forget the calculator,

--- a/tests/test_python_outputs.py
+++ b/tests/test_python_outputs.py
@@ -1,10 +1,15 @@
 """
-Tests for native Python output extraction (fz/outparsers.py).
+Tests for native output extraction (fz/outparsers.py): python://, jq://,
+yq://, xpath:// and the implicit-default / explicit bash:// shell form.
 
-These tests are fully shell-free: they must pass on any platform without
-bash, grep, awk or FZ_SHELL_PATH being available.
+The python://, jq://, yq:// and xpath:// tests are fully shell-free: they
+must pass on any platform without bash, grep, awk or FZ_SHELL_PATH being
+available (the jq/yq/xpath tests additionally require their respective
+executable and are skipped otherwise).
 """
 import json
+import platform
+import shutil
 from pathlib import Path
 
 import pytest
@@ -12,9 +17,45 @@ import pytest
 from fz import fzo
 from fz.outparsers import (
     evaluate_python_output,
+    evaluate_jq_output,
+    evaluate_yq_output,
+    evaluate_xpath_output,
     is_python_expression,
+    is_jq_expression,
+    is_yq_expression,
+    is_xpath_expression,
+    is_bash_expression,
+    strip_bash_prefix,
     make_helpers,
     strip_python_prefix,
+)
+
+requires_jq = pytest.mark.skipif(
+    shutil.which("jq") is None, reason="jq executable not found on PATH"
+)
+requires_yq = pytest.mark.skipif(
+    shutil.which("yq") is None, reason="yq executable not found on PATH"
+)
+requires_xmllint = pytest.mark.skipif(
+    shutil.which("xmllint") is None, reason="xmllint executable not found on PATH"
+)
+
+
+def _bash_available() -> bool:
+    if platform.system() != "Windows":
+        # grep/head/etc. are assumed present on Unix-like CI runners
+        return True
+    from fz.shell import get_windows_bash_executable
+    return get_windows_bash_executable() is not None
+
+
+# Guards the one test below that exercises a real "bash://" (shell) output
+# end-to-end. This file is otherwise deliberately shell-free (see the
+# shell-free-outputs.yml CI workflow, which runs it without bash on
+# Windows) — bash:// itself is not shell-free by design, so that single
+# test is skipped rather than making the whole file require bash.
+requires_bash = pytest.mark.skipif(
+    not _bash_available(), reason="bash not available on this platform"
 )
 
 
@@ -36,6 +77,18 @@ def output_dir(tmp_path):
     )
     (d / "result.json").write_text(json.dumps({"energy": 42.5, "steps": 10}))
     (d / "data.csv").write_text("t,T\n0,90\n300,55\n600,40\n")
+    (d / "config.yaml").write_text(
+        "metadata:\n"
+        "  version: 3\n"
+        "results:\n"
+        "  pressure: 101.325\n"
+    )
+    (d / "output.xml").write_text(
+        "<results>"
+        "<pressure>101.325</pressure>"
+        "<label>converged</label>"
+        "</results>"
+    )
     return d
 
 
@@ -44,8 +97,8 @@ def output_dir(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_is_python_expression_detection():
-    assert is_python_expression("python: grep(r'x=(\\d+)', 'f.txt')")
-    assert is_python_expression("  PYTHON: read('f.txt')")  # case/space tolerant
+    assert is_python_expression("python://grep(r'x=(\\d+)', 'f.txt')")
+    assert is_python_expression("  PYTHON://read('f.txt')")  # case/space tolerant
     assert not is_python_expression("grep 'pressure' output.txt | awk '{print $3}'")
     assert not is_python_expression("cat output.txt")
     assert not is_python_expression(42)
@@ -53,7 +106,52 @@ def test_is_python_expression_detection():
 
 
 def test_strip_python_prefix():
-    assert strip_python_prefix("python: 1 + 1") == "1 + 1"
+    assert strip_python_prefix("python://1 + 1") == "1 + 1"
+
+
+def test_is_jq_expression_detection():
+    assert is_jq_expression("jq://.energy result.json")
+    assert is_jq_expression("  JQ://.energy result.json")  # case/space tolerant
+    assert not is_jq_expression("python://json_file('result.json')")
+    assert not is_jq_expression("grep 'pressure' output.txt")
+    assert not is_jq_expression(42)
+
+
+def test_is_yq_expression_detection():
+    assert is_yq_expression("yq://.metadata.version config.yaml")
+    assert is_yq_expression("  YQ://.a result.json")  # case/space tolerant
+    assert not is_yq_expression("jq://.energy result.json")
+    assert not is_yq_expression("grep 'pressure' output.txt")
+    assert not is_yq_expression(42)
+
+
+def test_is_xpath_expression_detection():
+    assert is_xpath_expression("xpath://'//pressure/text()' out.xml")
+    assert is_xpath_expression("  XPATH://'//a' out.xml")  # case/space tolerant
+    assert not is_xpath_expression("yq://.a config.yaml")
+    assert not is_xpath_expression("grep 'pressure' output.txt")
+    assert not is_xpath_expression(42)
+
+
+def test_is_bash_expression_detection():
+    # implicit default: no recognized prefix -> bash
+    assert is_bash_expression("grep 'pressure' output.txt | awk '{print $3}'")
+    # explicit bash:// prefix
+    assert is_bash_expression("bash://cat output.txt")
+    assert is_bash_expression("BASH://cat output.txt")
+    # python://, jq://, yq:// and xpath:// are not bash expressions
+    assert not is_bash_expression("python://read('output.txt')")
+    assert not is_bash_expression("jq://.energy result.json")
+    assert not is_bash_expression("yq://.a config.yaml")
+    assert not is_bash_expression("xpath://'//a' out.xml")
+    assert not is_bash_expression(42)
+    assert not is_bash_expression(None)
+
+
+def test_strip_bash_prefix():
+    assert strip_bash_prefix("bash://cat output.txt") == "cat output.txt"
+    # no prefix -> returned unchanged (implicit default)
+    assert strip_bash_prefix("cat output.txt") == "cat output.txt"
 
 
 # ---------------------------------------------------------------------------
@@ -125,9 +223,90 @@ def test_evaluate_expression_with_hdf5(output_dir):
     with h5py.File(output_dir / "res.h5", "w") as f:
         f["results/T"] = [90.0, 55.0, 40.0]
     value = evaluate_python_output(
-        "python: min(hdf5_file('res.h5', 'results/T'))", output_dir
+        "python://min(hdf5_file('res.h5', 'results/T'))", output_dir
     )
     assert value == pytest.approx(40.0)
+
+
+# ---------------------------------------------------------------------------
+# jq:// evaluation (requires the jq executable)
+# ---------------------------------------------------------------------------
+
+@requires_jq
+def test_evaluate_jq_scalar(output_dir):
+    value = evaluate_jq_output("jq://.energy result.json", output_dir)
+    assert value == pytest.approx(42.5)
+
+
+@requires_jq
+def test_evaluate_jq_prefix_detection_and_stripping(output_dir):
+    # bare spec (prefix already stripped) also works
+    value = evaluate_jq_output(".steps result.json", output_dir)
+    assert value == 10
+
+
+@requires_jq
+def test_evaluate_jq_quoted_filter(output_dir):
+    (output_dir / "result.json").write_text(
+        json.dumps({"a": {"b": [10, 20, 30]}})
+    )
+    value = evaluate_jq_output("jq://'.a.b[1]' result.json", output_dir)
+    assert value == 20
+
+
+@requires_jq
+def test_jq_missing_filter_or_file_raises(output_dir):
+    with pytest.raises(ValueError):
+        evaluate_jq_output("jq://.energy", output_dir)
+
+
+# ---------------------------------------------------------------------------
+# yq:// evaluation (requires the mikefarah/yq executable)
+# ---------------------------------------------------------------------------
+
+@requires_yq
+def test_evaluate_yq_scalar(output_dir):
+    value = evaluate_yq_output("yq://.metadata.version config.yaml", output_dir)
+    assert value == 3
+
+
+@requires_yq
+def test_evaluate_yq_prefix_detection_and_stripping(output_dir):
+    # bare spec (prefix already stripped) also works
+    value = evaluate_yq_output(".results.pressure config.yaml", output_dir)
+    assert value == pytest.approx(101.325)
+
+
+@requires_yq
+def test_yq_missing_filter_or_file_raises(output_dir):
+    with pytest.raises(ValueError):
+        evaluate_yq_output("yq://.a", output_dir)
+
+
+# ---------------------------------------------------------------------------
+# xpath:// evaluation (requires the xmllint executable)
+# ---------------------------------------------------------------------------
+
+@requires_xmllint
+def test_evaluate_xpath_numeric(output_dir):
+    value = evaluate_xpath_output(
+        "xpath://'//pressure/text()' output.xml", output_dir
+    )
+    assert value == pytest.approx(101.325)
+
+
+@requires_xmllint
+def test_evaluate_xpath_string(output_dir):
+    value = evaluate_xpath_output(
+        "xpath://'//label/text()' output.xml", output_dir
+    )
+    assert value == "converged"
+
+
+@requires_xmllint
+def test_xpath_missing_expression_or_file_raises(output_dir):
+    with pytest.raises(ValueError):
+        evaluate_xpath_output("xpath://'//pressure/text()'", output_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -136,14 +315,14 @@ def test_evaluate_expression_with_hdf5(output_dir):
 
 def test_evaluate_expression(output_dir):
     value = evaluate_python_output(
-        "python: grep(r'temperature = (\\S+)', 'output.txt')", output_dir
+        "python://grep(r'temperature = (\\S+)', 'output.txt')", output_dir
     )
     assert value == pytest.approx(293.15)
 
 
 def test_evaluate_expression_with_computation(output_dir):
     value = evaluate_python_output(
-        "python: max(csv_file('data.csv', column='T'))", output_dir
+        "python://max(csv_file('data.csv', column='T'))", output_dir
     )
     assert value == 90
 
@@ -158,7 +337,7 @@ def test_evaluate_callable(output_dir):
 def test_numpy_scalar_normalized(output_dir):
     np = pytest.importorskip("numpy")
     value = evaluate_python_output(
-        "python: np.mean(np.array(csv_file('data.csv', column='T')))", output_dir
+        "python://np.mean(np.array(csv_file('data.csv', column='T')))", output_dir
     )
     assert not isinstance(value, np.generic)
     assert value == pytest.approx((90 + 55 + 40) / 3)
@@ -171,8 +350,8 @@ def test_numpy_scalar_normalized(output_dir):
 def test_fzo_with_python_outputs(output_dir):
     model = {
         "output": {
-            "pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')",
-            "energy": "python: json_file('result.json')['energy']",
+            "pressure": "python://grep(r'pressure = (\\S+)', 'output.txt')",
+            "energy": "python://json_file('result.json')['energy']",
             "T_final": lambda d: float((d / "data.csv").read_text().splitlines()[-1].split(",")[1]),
         }
     }
@@ -184,8 +363,25 @@ def test_fzo_with_python_outputs(output_dir):
     assert "_output_error" not in result.columns
 
 
+@requires_jq
+@requires_bash
+def test_fzo_with_mixed_python_jq_bash_outputs(output_dir):
+    model = {
+        "output": {
+            "pressure": "python://grep(r'pressure = (\\S+)', 'output.txt')",
+            "energy": "jq://.energy result.json",
+            "steps": "bash://grep -o steps result.json | head -1",
+        }
+    }
+    result = fzo(str(output_dir), model)
+    row = result.iloc[0]
+    assert row["pressure"] == pytest.approx(101.325)
+    assert row["energy"] == pytest.approx(42.5)
+    assert row["steps"] == "steps"
+
+
 def test_fzo_python_output_error_is_reported(output_dir):
-    model = {"output": {"missing": "python: read('does_not_exist.txt')"}}
+    model = {"output": {"missing": "python://read('does_not_exist.txt')"}}
     result = fzo(str(output_dir), model)
     row = result.iloc[0]
     assert row["missing"] is None or (row["missing"] != row["missing"])  # None/NaN
@@ -218,7 +414,7 @@ def test_check_bash_non_strict_does_not_raise(monkeypatch):
 
 def test_fzo_python_only_model_works_without_bash(output_dir, monkeypatch):
     _simulate_windows_without_bash(monkeypatch)
-    model = {"output": {"energy": "python: json_file('result.json')['energy']"}}
+    model = {"output": {"energy": "python://json_file('result.json')['energy']"}}
     result = fzo(str(output_dir), model)
     assert result.iloc[0]["energy"] == pytest.approx(42.5)
 

--- a/tests/test_python_outputs.py
+++ b/tests/test_python_outputs.py
@@ -100,6 +100,36 @@ def test_helper_csv_file_column(output_dir):
     assert h["csv_file"]("data.csv", column="T") == [90, 55, 40]
 
 
+def test_helper_hdf5_file(output_dir):
+    h5py = pytest.importorskip("h5py")
+    np = pytest.importorskip("numpy")
+    with h5py.File(output_dir / "res.h5", "w") as f:
+        f["energy"] = 42.5
+        f["results/T"] = np.array([90.0, 55.0, 40.0])
+        f["label"] = b"converged"
+
+    h = make_helpers(output_dir)
+    # top-level keys when no dataset given
+    assert sorted(h["hdf5_file"]("res.h5")) == ["energy", "label", "results"]
+    # scalar dataset -> native float
+    energy = h["hdf5_file"]("res.h5", "energy")
+    assert energy == pytest.approx(42.5) and isinstance(energy, float)
+    # array dataset (nested path) -> plain list
+    assert h["hdf5_file"]("res.h5", "results/T") == [90.0, 55.0, 40.0]
+    # bytes -> str
+    assert h["hdf5_file"]("res.h5", "label") == "converged"
+
+
+def test_evaluate_expression_with_hdf5(output_dir):
+    h5py = pytest.importorskip("h5py")
+    with h5py.File(output_dir / "res.h5", "w") as f:
+        f["results/T"] = [90.0, 55.0, 40.0]
+    value = evaluate_python_output(
+        "python: min(hdf5_file('res.h5', 'results/T'))", output_dir
+    )
+    assert value == pytest.approx(40.0)
+
+
 # ---------------------------------------------------------------------------
 # Expression / callable evaluation
 # ---------------------------------------------------------------------------
@@ -161,3 +191,40 @@ def test_fzo_python_output_error_is_reported(output_dir):
     assert row["missing"] is None or (row["missing"] != row["missing"])  # None/NaN
     assert "_output_error" in result.columns
     assert "missing" in str(row["_output_error"])
+
+
+# ---------------------------------------------------------------------------
+# Windows-without-bash behavior (simulated on any platform)
+# ---------------------------------------------------------------------------
+
+def _simulate_windows_without_bash(monkeypatch):
+    import platform
+    import fz.shell
+    import fz.core
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(fz.shell, "get_windows_bash_executable", lambda: None)
+    monkeypatch.setattr(fz.core, "platform", platform)
+
+
+def test_check_bash_non_strict_does_not_raise(monkeypatch):
+    from fz.core import check_bash_availability_on_windows
+    _simulate_windows_without_bash(monkeypatch)
+    # strict (default) raises with installation instructions
+    with pytest.raises(RuntimeError, match="bash is not available"):
+        check_bash_availability_on_windows()
+    # non-strict (import-time behavior) only warns
+    check_bash_availability_on_windows(strict=False)
+
+
+def test_fzo_python_only_model_works_without_bash(output_dir, monkeypatch):
+    _simulate_windows_without_bash(monkeypatch)
+    model = {"output": {"energy": "python: json_file('result.json')['energy']"}}
+    result = fzo(str(output_dir), model)
+    assert result.iloc[0]["energy"] == pytest.approx(42.5)
+
+
+def test_fzo_shell_model_raises_helpfully_without_bash(output_dir, monkeypatch):
+    _simulate_windows_without_bash(monkeypatch)
+    model = {"output": {"anything": "cat output.txt"}}
+    with pytest.raises(RuntimeError, match="bash is not available"):
+        fzo(str(output_dir), model)

--- a/tests/test_python_outputs.py
+++ b/tests/test_python_outputs.py
@@ -1,0 +1,163 @@
+"""
+Tests for native Python output extraction (fz/outparsers.py).
+
+These tests are fully shell-free: they must pass on any platform without
+bash, grep, awk or FZ_SHELL_PATH being available.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from fz import fzo
+from fz.outparsers import (
+    evaluate_python_output,
+    is_python_expression,
+    make_helpers,
+    strip_python_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def output_dir(tmp_path):
+    """A fake case output directory with typical result files."""
+    d = tmp_path / "case_output"
+    d.mkdir()
+    (d / "output.txt").write_text(
+        "iteration 1\n"
+        "pressure = 101.325 kPa\n"
+        "temperature = 293.15\n"
+        "pressure = 99.9 kPa\n"
+        "done\n"
+    )
+    (d / "result.json").write_text(json.dumps({"energy": 42.5, "steps": 10}))
+    (d / "data.csv").write_text("t,T\n0,90\n300,55\n600,40\n")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Spec detection
+# ---------------------------------------------------------------------------
+
+def test_is_python_expression_detection():
+    assert is_python_expression("python: grep(r'x=(\\d+)', 'f.txt')")
+    assert is_python_expression("  PYTHON: read('f.txt')")  # case/space tolerant
+    assert not is_python_expression("grep 'pressure' output.txt | awk '{print $3}'")
+    assert not is_python_expression("cat output.txt")
+    assert not is_python_expression(42)
+    assert not is_python_expression(None)
+
+
+def test_strip_python_prefix():
+    assert strip_python_prefix("python: 1 + 1") == "1 + 1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_helper_read_and_lines(output_dir):
+    h = make_helpers(output_dir)
+    assert "pressure = 101.325 kPa" in h["read"]("output.txt")
+    assert h["lines"]("output.txt")[0] == "iteration 1"
+    assert h["line"]("output.txt", -1) == "done"
+
+
+def test_helper_grep_first_match_with_cast(output_dir):
+    h = make_helpers(output_dir)
+    value = h["grep"](r"pressure = (\S+)", "output.txt")
+    assert value == pytest.approx(101.325)
+    assert isinstance(value, float)
+
+
+def test_helper_grep_all_matches(output_dir):
+    h = make_helpers(output_dir)
+    values = h["grep"](r"pressure = (\S+)", "output.txt", all=True)
+    assert values == [pytest.approx(101.325), pytest.approx(99.9)]
+
+
+def test_helper_grep_no_match_returns_none(output_dir):
+    h = make_helpers(output_dir)
+    assert h["grep"](r"velocity = (\S+)", "output.txt") is None
+
+
+def test_helper_grep_whole_match_without_groups(output_dir):
+    h = make_helpers(output_dir)
+    assert h["grep"](r"iteration \d+", "output.txt", cast=False) == "iteration 1"
+
+
+def test_helper_json_file(output_dir):
+    h = make_helpers(output_dir)
+    assert h["json_file"]("result.json")["energy"] == 42.5
+
+
+def test_helper_csv_file_column(output_dir):
+    h = make_helpers(output_dir)
+    assert h["csv_file"]("data.csv", column="T") == [90, 55, 40]
+
+
+# ---------------------------------------------------------------------------
+# Expression / callable evaluation
+# ---------------------------------------------------------------------------
+
+def test_evaluate_expression(output_dir):
+    value = evaluate_python_output(
+        "python: grep(r'temperature = (\\S+)', 'output.txt')", output_dir
+    )
+    assert value == pytest.approx(293.15)
+
+
+def test_evaluate_expression_with_computation(output_dir):
+    value = evaluate_python_output(
+        "python: max(csv_file('data.csv', column='T'))", output_dir
+    )
+    assert value == 90
+
+
+def test_evaluate_callable(output_dir):
+    value = evaluate_python_output(
+        lambda d: json.loads((d / "result.json").read_text())["steps"], output_dir
+    )
+    assert value == 10
+
+
+def test_numpy_scalar_normalized(output_dir):
+    np = pytest.importorskip("numpy")
+    value = evaluate_python_output(
+        "python: np.mean(np.array(csv_file('data.csv', column='T')))", output_dir
+    )
+    assert not isinstance(value, np.generic)
+    assert value == pytest.approx((90 + 55 + 40) / 3)
+
+
+# ---------------------------------------------------------------------------
+# Integration with fzo (no shell involved)
+# ---------------------------------------------------------------------------
+
+def test_fzo_with_python_outputs(output_dir):
+    model = {
+        "output": {
+            "pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')",
+            "energy": "python: json_file('result.json')['energy']",
+            "T_final": lambda d: float((d / "data.csv").read_text().splitlines()[-1].split(",")[1]),
+        }
+    }
+    result = fzo(str(output_dir), model)
+    row = result.iloc[0]
+    assert row["pressure"] == pytest.approx(101.325)
+    assert row["energy"] == pytest.approx(42.5)
+    assert row["T_final"] == pytest.approx(40.0)
+    assert "_output_error" not in result.columns
+
+
+def test_fzo_python_output_error_is_reported(output_dir):
+    model = {"output": {"missing": "python: read('does_not_exist.txt')"}}
+    result = fzo(str(output_dir), model)
+    row = result.iloc[0]
+    assert row["missing"] is None or (row["missing"] != row["missing"])  # None/NaN
+    assert "_output_error" in result.columns
+    assert "missing" in str(row["_output_error"])


### PR DESCRIPTION
# Titre de la PR

**Add native Python output extraction (`python:` expressions and callables) — no shell required**

# Description (à coller dans GitHub)

## Summary

This PR adds a shell-free way to extract outputs in fz models. `output` values can now be, in addition to the existing shell commands:

1. **`python:`-prefixed expressions**, evaluated in each case's result directory:

```python
"output": {
    "pressure": "python: grep(r'pressure = (\\S+)', 'output.txt')",
    "energy":   "python: json_file('results.json')['energy']",
    "T_max":    "python: max(csv_file('temps.csv', column='T'))"
}
```

2. **Callables** (Python API only), receiving the result directory as a `pathlib.Path`:

```python
"output": {"T_final": lambda d: float((d / "final.txt").read_text())}
```

## Motivation

Output parsing currently relies on shell pipelines (`grep | awk`), which is fz's main portability weak point: it requires bash on Windows (`FZ_SHELL_PATH`, MSYS2/Git-Bash detection) and is exposed to quoting (`$3` vs `\$3`) and locale (`LC_ALL`) pitfalls — all of which the agent skill currently has to warn about. Native Python extraction removes the external-tool dependency entirely for new models, while remaining 100% backward compatible.

## Design

- New module `fz/outparsers.py`: spec detection (`python:` prefix, case/whitespace tolerant), helper namespace factory, and evaluation. Helpers resolve relative paths against the case result directory, mirroring the cwd semantics of legacy shell commands.
- Helper namespace: `read`, `lines`, `line`, `grep` (returns first capture group, auto-cast to int/float, `all=True` for lists), `json_file`, `csv_file`, plus `re`, `json`, `math`, `statistics`, `np`, `pd`, `Path`, `base_dir`.
- Dispatch added at the single output-execution point in `fzo` (`fz/core.py`); errors are reported through the existing `_output_error` mechanism.
- Validation in `fz/helpers.py` relaxed to accept callables.
- numpy scalars are normalized to native Python types for clean DataFrame/JSON round-trips.
- Security model unchanged: expressions are `eval`-ed with the same trust level as legacy shell commands, which are already executed verbatim (documented in the module docstring).
- Works transparently with `fzo --output-cmd NAME="python: ..."` on the CLI (string spec).

## Docs & skill

- `doc/model-definition.md`: new "Native Python extraction" subsection with helper reference.
- `README.md`: shell-free alternative shown in the quickstart model.
- `skills/fz/SKILL.md`: the agent skill now recommends shell-free outputs when authoring new models (fewer quoting/locale warnings needed).
- `NEWS.md`: Unreleased entry.

## Windows / no-bash support

This PR also removes the hard bash requirement at import time. Previously `import fz` raised on Windows without bash — making even shell-free workflows impossible. Now:

- `check_bash_availability_on_windows()` gains a `strict` parameter; `fz/__init__.py` calls it with `strict=False` (warning instead of error). All existing tests asserting the strict behavior are unchanged and still pass.
- `fzo` performs the **strict** check at use time, only when the model actually contains legacy shell-command outputs — users still get the full installation instructions exactly when they need them.
- A dedicated CI workflow, `.github/workflows/shell-free-outputs.yml`, runs the python-output tests on a **bare `windows-latest` runner** (plus ubuntu/macos): no MSYS2 install, `FZ_SHELL_PATH` unset, and Git-Bash/msys/cygwin directories stripped from `PATH`, with an explicit step verifying `bash` is unreachable. Any hidden shell dependency in this code path fails loudly in CI.

## HDF5 helper

`hdf5_file(path, dataset=None)` reads HDF5 results (optional `h5py` dependency, with a clear ImportError message otherwise). Nested dataset paths supported (`"results/T"`); values are converted to native Python types (scalars, lists, str) for clean DataFrame/JSON round-trips; omitting `dataset` returns the top-level keys for exploration.

## Tests

20 new tests in `tests/test_python_outputs.py`, deliberately **shell-free** (must pass on any platform without bash): spec detection, each helper, expression/callable evaluation, numpy normalization, `fzo` integration (mixed model), and error reporting via `_output_error`.

`pytest tests/test_python_outputs.py` → 20 passed, including simulated Windows-without-bash scenarios (import OK, python-only `fzo` works, shell model raises the helpful error). Related subsets (`-k "output or model or helper"`) → no regression (the 2 failures observed are pre-existing on main in a root environment: permission-based tests).

## Backward compatibility

Fully backward compatible: shell-command strings behave exactly as before and can be mixed with Python outputs in the same model. No change to caching, hashing, or the funz legacy protocol.

## Possible follow-ups (out of scope)

- Deprecation path or lint hint suggesting `python:` equivalents for common `grep|awk` patterns
- Same dispatch for remote calculators that post-process outputs server-side
- Migrate the official model wrappers' output commands to `python:` form
