### PR TITLE
Vector-valued outputs as fzd objectives, plus multi-objective (NSGA-II) support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,22 @@
   output(s) and suggesting a reduction (e.g. `mean(T_series)`); the
   affected point is reported as a failed evaluation (`None`), like any
   other per-case error — it does not stop the run.
+- Two *different* vector outputs can be combined in the same expression:
+  plain `+` concatenates two lists (`mean(a + b)` pools both before
+  averaging), and the new `zip()` helper combines them element-wise, e.g.
+  `sqrt(sum((x - y) ** 2 for x, y in zip(sim, ref)) / len(sim))` for an
+  RMSE/residual between a simulated and a reference series.
+- Fixed a related bug this uncovered: `evaluate_output_expression()` used
+  to evaluate with a split globals/locals dict
+  (`eval(expr, {"__builtins__": {}}, safe_dict)`), which made any
+  generator-expression or comprehension body unable to see the output
+  variables or helper functions (Python resolves names inside a nested
+  comprehension/genexp scope through *globals* only, never through a
+  separately-passed locals dict) — e.g. `max(abs(x - y) for x, y in
+  zip(a, b))` used to fail with a spurious `name 'abs' is not defined`.
+  Now uses a single combined globals dict, so any output variable or
+  helper function works the same whether referenced directly or from
+  inside a generator/comprehension body.
 - `fzd`'s objective itself is still a single scalar per case (no
   multi-objective / vector-objective optimization) — this only concerns
   reducing a vector-valued model *output* to that scalar.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # FZ Release Notes
 
+## Unreleased (feat/vector-objectives-fzd)
+
+### Multi-objective (vector) objectives in fzd
+
+- `fzd()`'s `output_expression` now also accepts a **list of expressions**:
+  each case then yields a list of scalars (one per expression, same order),
+  passed as-is to the algorithm's `get_next_design()`/`get_analysis()`.
+  A plain string keeps the legacy single-scalar behavior unchanged.
+  This completes the vector-output work of #75/#76: #76 reduces vector
+  *outputs* to a scalar objective; this change allows the *objective itself*
+  to be a vector, enabling native multi-objective algorithms.
+- New `evaluate_output_expressions()` in `fz/algorithms.py` (str or list of
+  str); XY DataFrame and `Y_<iteration>.csv` gain one column per objective.
+- New example algorithm `examples/algorithms/nsga2.py`: NSGA-II (Deb 2002)
+  at the fzd plugin format — batch-parallel generations, SBX + polynomial
+  mutation, Pareto front written to `nsga2_pareto.csv` and returned in the
+  analysis `data` (`pareto_X`/`pareto_F`). Objectives are all minimized;
+  negate an expression to maximize. Validated against the analytic Pareto
+  front of the Binh-Korn problem (objective-space deviation < 3%).
+- 8 new tests in `tests/test_fzd_multiobjective.py`; no regressions on
+  `test_fzd.py`, `test_fzd_vector_outputs.py`, `test_algorithm_options.py`,
+  `test_algorithm_plugins.py` (85 passed).
+
+
 ## Unreleased
 
 ### Native shell-free output extraction: python://, jq://, yq://, xpath://

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,25 @@
   objective per case; vector-output support there is tracked as a
   follow-up.
 
+### Vector-valued outputs as fzd objectives
+
+- `output_expression` (the expression `fzd` evaluates to get its scalar
+  objective per case) can now reduce a vector-valued output (a time
+  series, a per-node profile, ...) down to that scalar: `sum()`, `len()`,
+  `sorted()`, `mean()`, `median()`, `stdev()`, `variance()` join the
+  existing math functions and indexing/slicing (`series[-1]`) available in
+  `evaluate_output_expression`.
+- Referencing a vector-valued output without reducing it (e.g.
+  `output_expression="T_series"` on its own) used to fail with a bare
+  `float() argument must be a string or a real number, not 'list'`
+  `TypeError`. It now raises a clear `ValueError` naming the offending
+  output(s) and suggesting a reduction (e.g. `mean(T_series)`); the
+  affected point is reported as a failed evaluation (`None`), like any
+  other per-case error — it does not stop the run.
+- `fzd`'s objective itself is still a single scalar per case (no
+  multi-objective / vector-objective optimization) — this only concerns
+  reducing a vector-valued model *output* to that scalar.
+
 ## Version 1.1 (2026-06-15)
 
 ### CLI argument aliases (README forms now work)

--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,11 @@ always need a single scalar objective, so `output_expression` is where
 such a vector gets reduced: on top of `abs()`/`min()`/`max()`/`sqrt()`/...
 and indexing/slicing (`series[-1]`), the reduction functions `sum()`,
 `len()`, `sorted()`, `mean()`, `median()`, `stdev()`, `variance()` are
-available, e.g. `output_expression="mean(T_series)"`. Referencing a
+available, e.g. `output_expression="mean(T_series)"`. Two different vector
+outputs can be combined too: plain `+` concatenates them before reducing
+(`mean(a + b)`), and `zip()` combines them element-wise, e.g.
+`output_expression="sqrt(sum((x - y) ** 2 for x, y in zip(sim, ref)) / len(sim))"`
+for an RMSE between a simulated and a reference series. Referencing a
 vector-valued output without reducing it raises a clear error naming the
 output and suggesting a fix; that point is simply reported as a failed
 evaluation, it does not stop the run. See `examples/fzd_example.md`,

--- a/README.md
+++ b/README.md
@@ -1136,6 +1136,18 @@ print(results['summary'])  # Algorithm completion summary
 - **Cross-iteration caching**: results from previous iterations are automatically reused — a point evaluated in iteration 2 is never re-run in iteration 5
 - **Re-run resume**: if `analysis_dir` already exists it is renamed with a timestamp; all its iteration subdirectories are still consulted as cache, so a re-run with different options benefits from all prior computations
 
+**Vector-valued outputs as objectives**: a case's model output can be a
+vector (list) — see the "Vector (array) Outputs" section. `fzd`'s algorithms
+always need a single scalar objective, so `output_expression` is where
+such a vector gets reduced: on top of `abs()`/`min()`/`max()`/`sqrt()`/...
+and indexing/slicing (`series[-1]`), the reduction functions `sum()`,
+`len()`, `sorted()`, `mean()`, `median()`, `stdev()`, `variance()` are
+available, e.g. `output_expression="mean(T_series)"`. Referencing a
+vector-valued output without reducing it raises a clear error naming the
+output and suggesting a fix; that point is simply reported as a failed
+evaluation, it does not stop the run. See `examples/fzd_example.md`,
+"Vector-valued outputs as objectives".
+
 ### Input Variables: Factorial vs Non-Factorial Designs
 
 FZ supports two types of parametric study designs through different `input_variables` formats:

--- a/doc/INDEX.md
+++ b/doc/INDEX.md
@@ -76,6 +76,7 @@ Quick reference index for finding specific topics in the FZ context documentatio
 | fzd fixed vs range variables | core-functions.md | "fzd" → "Fixed vs. Range Variables" |
 | fzd batch deduplication | core-functions.md | "fzd" → "Batch Deduplication" |
 | fzd auto caching between iterations | core-functions.md | "fzd" → "Automatic Caching Between Iterations" |
+| fzd vector-valued outputs as objectives | core-functions.md | "fzd" → "Vector-valued outputs as objectives" |
 | fzd analysis content formats | fzd_content_format.md | "Supported Formats" |
 | fzl (list models/calculators) | core-functions.md | "fzl - List and Validate Models/Calculators" |
 | Function signatures | core-functions.md | Each function section → "Function Signature" |
@@ -255,6 +256,7 @@ Quick keyword search:
 - **fzl**: core-functions.md → "fzl - List and Validate Models/Calculators"
 - **Algorithm**: core-functions.md → "fzd", examples/fzd_example.md
 - **Optimization**: core-functions.md → "fzd", examples/fzd_example.md
+- **Vector outputs as fzd objectives**: core-functions.md → "fzd" → "Vector-valued outputs as objectives", examples/fzd_example.md → "Vector-valued outputs as objectives"
 - **Fixed variable**: core-functions.md → "fzd" → "Fixed vs. Range Variables"
 - **Deduplication**: core-functions.md → "fzd" → "Batch Deduplication"
 - **fzd content format**: fzd_content_format.md

--- a/doc/core-functions.md
+++ b/doc/core-functions.md
@@ -739,6 +739,31 @@ raises a clear error naming the offending output and suggesting a fix,
 and that point's evaluation is simply reported as failed (`None`), like
 any other per-case error.
 
+**Combining two different vector outputs**: a model can expose more than
+one vector output (e.g. a simulated series and a reference/target one for
+calibration), and `output_expression` can combine them in two ways:
+
+```python
+model = {
+    "output": {
+        "T_series": "python://json_file('series.json')",  # simulated
+        "T_ref": "python://json_file('ref.json')",         # reference
+    }
+}
+
+# Concatenate then reduce: plain "+" on two lists concatenates them, no
+# extra helper needed -- pools every value from both series before
+# averaging.
+output_expression = "mean(T_series + T_ref)"
+
+# Combine two independent reductions.
+output_expression = "mean(T_series) - mean(T_ref)"
+
+# Combine element-wise with zip(): the natural way to score a simulated
+# series against a reference one, e.g. as an RMSE objective.
+output_expression = "sqrt(sum((x - y) ** 2 for x, y in zip(T_series, T_ref)) / len(T_series))"
+```
+
 ### Algorithm Interface
 
 Custom algorithms must implement a class with these methods:

--- a/doc/core-functions.md
+++ b/doc/core-functions.md
@@ -764,6 +764,29 @@ output_expression = "mean(T_series) - mean(T_ref)"
 output_expression = "sqrt(sum((x - y) ** 2 for x, y in zip(T_series, T_ref)) / len(T_series))"
 ```
 
+### Multi-objective (vector) objectives
+
+`output_expression` may be a **list of expressions** for multi-objective
+algorithms: each case yields one scalar per expression, and the algorithm's
+`get_next_design()`/`get_analysis()` receive lists of floats instead of
+floats. All objectives are minimized by convention; negate an expression to
+maximize it. Reductions over vector-valued outputs work in each expression,
+so both features compose:
+
+```python
+result = fzd(
+    "input.txt", {"e": "[0;0.3]", "P": "[0;4000]"}, model,
+    ["19 - min(Tser)",          # winter deficit  (minimize)
+     "max(Tser) - 26"],         # summer excess   (minimize)
+    "examples/algorithms/nsga2.py",
+    algorithm_options={"pop_size": 24, "generations": 15},
+)
+result["XY"]                    # one column per objective expression
+result["analysis"]["data"]["pareto_X"]   # Pareto-optimal designs
+```
+
+A plain string keeps the legacy single-scalar behavior unchanged.
+
 ### Algorithm Interface
 
 Custom algorithms must implement a class with these methods:

--- a/doc/core-functions.md
+++ b/doc/core-functions.md
@@ -702,6 +702,43 @@ result = fz.fzd(
 )
 ```
 
+### Vector-valued outputs as objectives
+
+A case's model output does not have to be a single number — `fzo`/`fzr`
+already store vector outputs (a time series, a per-node profile, ...) as
+plain Python lists (see `doc/model-definition.md`, "Vector / array
+outputs"). `fzd`'s algorithms, though, always work with a single scalar
+objective per case, so `output_expression` is where a vector output gets
+reduced. On top of the usual math functions and indexing/slicing
+(`series[-1]`, `series[:5]`), the following reduction functions are
+available: `sum()`, `len()`, `sorted()`, `mean()`, `median()`, `stdev()`,
+`variance()`.
+
+```python
+model = {
+    "varprefix": "$",
+    "output": {"T_series": "python://json_file('series.json')"},
+}
+
+result = fz.fzd(
+    input_path="input.txt",
+    input_variables={"T0": "[50;200]"},
+    model=model,
+    output_expression="mean(T_series)",   # average the whole series
+    # or: "T_series[-1]" (final value), "max(T_series) - min(T_series)"
+    # (peak-to-peak), "sqrt(sum(v**2 for v in T_series) / len(T_series))" (RMS)
+    algorithm="examples/algorithms/randomsampling.py",
+    calculators="sh://bash run_case.sh",
+    algorithm_options={"nvalues": 20, "seed": 42}
+)
+```
+
+Referencing a vector-valued output *without* reducing it (e.g.
+`output_expression="T_series"` on its own) does not crash the run: it
+raises a clear error naming the offending output and suggesting a fix,
+and that point's evaluation is simply reported as failed (`None`), like
+any other per-case error.
+
 ### Algorithm Interface
 
 Custom algorithms must implement a class with these methods:

--- a/examples/algorithms/nsga2.py
+++ b/examples/algorithms/nsga2.py
@@ -1,0 +1,235 @@
+#title: NSGA-II Multi-Objective Optimization (Deb 2002)
+#author: fz contributors
+#type: optimization
+#options: pop_size=24;generations=15;seed=42;eta_cx=15;eta_mut=20;p_cx=0.9
+
+"""
+NSGA-II as a native fzd algorithm.
+
+Requires fzd's vector-objective support: pass output_expression as a LIST of
+expressions, e.g.::
+
+    fzd("input.txt", {"x": "[0;1]", "y": "[0;1]"}, model,
+        ["19 - min(Tser)", "max(Tser) - 26"],       # objectives, all MINIMIZED
+        "examples/algorithms/nsga2.py",
+        algorithm_options={"pop_size": 24, "generations": 15})
+
+Each case's output value is then a list of floats (one per expression); this
+algorithm receives those lists and performs standard NSGA-II (fast
+non-dominated sorting, crowding distance, binary tournament, SBX crossover,
+polynomial mutation). To MAXIMIZE an objective, negate its expression.
+
+Populations are returned as batches, so fzd evaluates each generation in
+parallel across the available calculators. Failed cases (None) are treated
+as dominated by everything. get_analysis() reports the final Pareto front
+and writes it to nsga2_pareto.csv in the working directory.
+
+Pure stdlib + random module: no numpy dependency, consistent with the other
+example algorithms.
+"""
+
+import random
+
+
+class Nsga2:
+    """NSGA-II for fzd: multi-objective, generational, batch-parallel."""
+
+    def __init__(self, **options):
+        self.N = int(float(options.get('pop_size', 24)))
+        self.G = int(float(options.get('generations', 15)))
+        self.seed = int(float(options.get('seed', 42)))
+        self.eta_cx = float(options.get('eta_cx', 15))
+        self.eta_mut = float(options.get('eta_mut', 20))
+        self.p_cx = float(options.get('p_cx', 0.9))
+        self.rng = random.Random(self.seed)
+        self.names, self.lo, self.hi = [], [], []
+        self.X, self.F = [], []        # current population (lists)
+        self.gen = 0
+        self.consumed = 0
+        self._pending = []
+
+    # ------------------------------------------------------------------ utils
+    def _clip(self, x):
+        return [min(self.hi[i], max(self.lo[i], v)) for i, v in enumerate(x)]
+
+    def _todict(self, x):
+        return {n: float(v) for n, v in zip(self.names, x)}
+
+    @staticmethod
+    def _as_vector(out):
+        """Normalize one case output to a list of floats, or None if invalid."""
+        if out is None:
+            return None
+        if isinstance(out, (list, tuple)):
+            if any(v is None for v in out):
+                return None
+            return [float(v) for v in out]
+        return [float(out)]           # degenerate mono-objective use
+
+    @staticmethod
+    def _dominates(a, b):
+        return all(x <= y for x, y in zip(a, b)) and any(x < y for x, y in zip(a, b))
+
+    def _fronts(self, F):
+        n = len(F)
+        S = [[] for _ in range(n)]
+        nd = [0]*n
+        fronts = [[]]
+        for p in range(n):
+            for q in range(n):
+                if self._dominates(F[p], F[q]):
+                    S[p].append(q)
+                elif self._dominates(F[q], F[p]):
+                    nd[p] += 1
+            if nd[p] == 0:
+                fronts[0].append(p)
+        i = 0
+        while fronts[i]:
+            nxt = []
+            for p in fronts[i]:
+                for q in S[p]:
+                    nd[q] -= 1
+                    if nd[q] == 0:
+                        nxt.append(q)
+            i += 1
+            fronts.append(nxt)
+        return fronts[:-1]
+
+    @staticmethod
+    def _crowding(F):
+        n = len(F)
+        if n == 0:
+            return []
+        m = len(F[0])
+        d = [0.0]*n
+        for k in range(m):
+            order = sorted(range(n), key=lambda i: F[i][k])
+            d[order[0]] = d[order[-1]] = float('inf')
+            span = F[order[-1]][k] - F[order[0]][k]
+            if span > 0:
+                for j in range(1, n - 1):
+                    d[order[j]] += (F[order[j+1]][k] - F[order[j-1]][k]) / span
+        return d
+
+    # ------------------------------------------------------- genetic operators
+    def _sbx(self, p1, p2):
+        c1, c2 = list(p1), list(p2)
+        if self.rng.random() > self.p_cx:
+            return c1, c2
+        for i in range(len(self.names)):
+            if self.rng.random() > 0.5 or abs(p1[i] - p2[i]) < 1e-12:
+                continue
+            u = self.rng.random()
+            if u <= 0.5:
+                beta = (2*u)**(1/(self.eta_cx + 1))
+            else:
+                beta = (1/(2*(1 - u)))**(1/(self.eta_cx + 1))
+            c1[i] = 0.5*((1 + beta)*p1[i] + (1 - beta)*p2[i])
+            c2[i] = 0.5*((1 - beta)*p1[i] + (1 + beta)*p2[i])
+        return c1, c2
+
+    def _mutate(self, x):
+        p_mut = 1.0/len(self.names)
+        for i in range(len(self.names)):
+            if self.rng.random() < p_mut:
+                u = self.rng.random()
+                if u < 0.5:
+                    delta = (2*u)**(1/(self.eta_mut + 1)) - 1
+                else:
+                    delta = 1 - (2*(1 - u))**(1/(self.eta_mut + 1))
+                x[i] += delta*(self.hi[i] - self.lo[i])
+        return x
+
+    def _tournament(self, ranks, crowd):
+        i = self.rng.randrange(self.N)
+        j = self.rng.randrange(self.N)
+        if ranks[i] != ranks[j]:
+            return i if ranks[i] < ranks[j] else j
+        return i if crowd[i] >= crowd[j] else j
+
+    def _reproduce(self):
+        fronts = self._fronts(self.F)
+        ranks = [0]*self.N
+        crowd = [0.0]*self.N
+        for r, fr in enumerate(fronts):
+            cd = self._crowding([self.F[i] for i in fr])
+            for i, c in zip(fr, cd):
+                ranks[i] = r
+                crowd[i] = c
+        children = []
+        while len(children) < self.N:
+            a = self.X[self._tournament(ranks, crowd)]
+            b = self.X[self._tournament(ranks, crowd)]
+            c1, c2 = self._sbx(a, b)
+            children.append(self._clip(self._mutate(c1)))
+            if len(children) < self.N:
+                children.append(self._clip(self._mutate(c2)))
+        return children
+
+    # ------------------------------------------------------------ fzd interface
+    def get_initial_design(self, input_vars, output_vars):
+        self.names = list(input_vars.keys())
+        for n in self.names:
+            lo, hi = input_vars[n]
+            self.lo.append(float(lo))
+            self.hi.append(float(hi))
+        self._pending = [[self.lo[i] + self.rng.random()*(self.hi[i] - self.lo[i])
+                          for i in range(len(self.names))]
+                         for _ in range(self.N)]
+        return [self._todict(x) for x in self._pending]
+
+    def get_next_design(self, all_inputs, all_outputs):
+        # collect this generation's evaluations
+        new_X, new_F = [], []
+        worst = None
+        for inp, out in zip(all_inputs[self.consumed:], all_outputs[self.consumed:]):
+            new_X.append([float(inp[n]) for n in self.names])
+            new_F.append(self._as_vector(out))
+        self.consumed = len(all_outputs)
+        n_obj = next((len(f) for f in new_F + self.F if f is not None), 1)
+        big = [float('inf')]*n_obj
+        new_F = [f if f is not None else big for f in new_F]
+
+        if not self.F:                      # generation 0
+            self.X, self.F = new_X, new_F
+        else:                               # (mu + lambda) environmental selection
+            X_all = self.X + new_X
+            F_all = self.F + new_F
+            keep = []
+            for fr in self._fronts(F_all):
+                if len(keep) + len(fr) <= self.N:
+                    keep += fr
+                else:
+                    cd = self._crowding([F_all[i] for i in fr])
+                    ranked = sorted(zip(fr, cd), key=lambda t: -t[1])
+                    keep += [i for i, _ in ranked[: self.N - len(keep)]]
+                    break
+            self.X = [X_all[i] for i in keep]
+            self.F = [F_all[i] for i in keep]
+
+        self.gen += 1
+        if self.gen >= self.G:
+            return []
+        self._pending = self._reproduce()
+        return [self._todict(x) for x in self._pending]
+
+    def get_analysis(self, all_inputs, all_outputs):
+        import csv
+        import os
+        front_idx = self._fronts(self.F)[0] if self.F else []
+        finite = [i for i in front_idx if all(v != float('inf') for v in self.F[i])]
+        n_obj = len(self.F[0]) if self.F else 0
+        path = os.path.abspath("nsga2_pareto.csv")
+        with open(path, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(self.names + [f"objective_{k+1}" for k in range(n_obj)])
+            for i in finite:
+                w.writerow(self.X[i] + self.F[i])
+        lines = [f"NSGA-II: {self.gen} generations, {self.consumed} evaluations, "
+                 f"Pareto front: {len(finite)} points -> {path}"]
+        for i in finite[:10]:
+            objs = ", ".join(f"{v:.4g}" for v in self.F[i])
+            lines.append("  " + self._todict(self.X[i]).__repr__() + f" -> [{objs}]")
+        return {"text": "\n".join(lines),
+                "data": {"pareto_X": [self.X[i] for i in finite],
+                         "pareto_F": [self.F[i] for i in finite]}}

--- a/examples/fzd_example.md
+++ b/examples/fzd_example.md
@@ -284,8 +284,13 @@ print(f"  r1 + r2 * 2 = {df.loc[best_idx, 'r1 + r2 * 2']:.6f}")
 The output expression supports:
 - **Arithmetic:** `+`, `-`, `*`, `/`, `**` (power)
 - **Functions:** `abs()`, `min()`, `max()`, `sqrt()`, `exp()`, `log()`, etc.
+- **Reduction functions (for vector-valued outputs):** `sum()`, `len()`,
+  `sorted()`, `mean()`, `median()`, `stdev()`, `variance()`
 - **Math constants:** `pi`, `e`
-- **Model outputs:** Any variable from `model["output"]`
+- **Model outputs:** Any variable from `model["output"]` — scalars, or
+  vectors (lists) as described in `doc/model-definition.md`, "Vector /
+  array outputs"
+- **Indexing/slicing:** plain Python syntax (`series[-1]`, `series[:5]`)
 
 ### Example Expressions
 
@@ -299,12 +304,31 @@ output_expression = "0.7 * pressure + 0.3 * temperature"
 # Constraint violation penalty
 output_expression = "cost + 1000 * max(0, temperature - 100)"
 
-# Root mean square
+# Root mean square, over a fixed small number of scalar outputs
 output_expression = "sqrt((x1**2 + x2**2 + x3**2) / 3)"
 
-# Array indexing (for trajectory data)
+# Array indexing (for trajectory / time-series data)
 output_expression = "res_x[-1]"  # Last element
+
+# Reducing a vector output (e.g. a time series produced by
+# "python://json_file('series.json')") down to fzd's scalar objective
+output_expression = "mean(T_series)"                      # average value
+output_expression = "sum(T_series) / len(T_series)"        # equivalent, spelled out
+output_expression = "max(T_series) - min(T_series)"         # peak-to-peak amplitude
+output_expression = "sqrt(sum(v**2 for v in T_series) / len(T_series))"  # RMS
 ```
+
+### Vector-valued outputs as objectives
+
+If a case's model output is a vector (see `doc/model-definition.md`,
+"Vector / array outputs" — a time series, a per-node profile, ...), the
+`output_expression` is where it gets reduced to the single scalar every
+`fzd` algorithm expects. Referencing a vector-valued output *without*
+reducing it (e.g. `output_expression="T_series"` on its own) raises a
+clear error naming the offending output and suggesting a fix, rather than
+a bare type error; that point's evaluation is then reported as failed
+(`None`), exactly like any other per-case error — it does not stop the
+run.
 
 ---
 

--- a/examples/fzd_example.md
+++ b/examples/fzd_example.md
@@ -286,6 +286,7 @@ The output expression supports:
 - **Functions:** `abs()`, `min()`, `max()`, `sqrt()`, `exp()`, `log()`, etc.
 - **Reduction functions (for vector-valued outputs):** `sum()`, `len()`,
   `sorted()`, `mean()`, `median()`, `stdev()`, `variance()`
+- **`zip()`:** to combine two *different* vector outputs element-wise
 - **Math constants:** `pi`, `e`
 - **Model outputs:** Any variable from `model["output"]` — scalars, or
   vectors (lists) as described in `doc/model-definition.md`, "Vector /
@@ -316,6 +317,12 @@ output_expression = "mean(T_series)"                      # average value
 output_expression = "sum(T_series) / len(T_series)"        # equivalent, spelled out
 output_expression = "max(T_series) - min(T_series)"         # peak-to-peak amplitude
 output_expression = "sqrt(sum(v**2 for v in T_series) / len(T_series))"  # RMS
+
+# Combining two DIFFERENT vector outputs (e.g. T_series simulated vs a
+# T_ref reference/target series of the same length)
+output_expression = "mean(T_series + T_ref)"                # concatenate ("+") then reduce -- pools both series
+output_expression = "mean(T_series) - mean(T_ref)"           # combine two independent reductions
+output_expression = "sqrt(sum((x - y) ** 2 for x, y in zip(T_series, T_ref)) / len(T_series))"  # RMSE, element-wise via zip()
 ```
 
 ### Vector-valued outputs as objectives
@@ -329,6 +336,27 @@ clear error naming the offending output and suggesting a fix, rather than
 a bare type error; that point's evaluation is then reported as failed
 (`None`), exactly like any other per-case error — it does not stop the
 run.
+
+A model can expose more than one vector output at once (e.g. a simulated
+series and a reference/target one for calibration). Two ways to combine
+them:
+
+```python
+model = {
+    "output": {
+        "T_series": "python://json_file('series.json')",  # simulated
+        "T_ref": "python://json_file('ref.json')",         # reference
+    }
+}
+
+# Concatenate (plain "+" on two lists) then reduce -- pools every value
+# from both series before averaging.
+output_expression = "mean(T_series + T_ref)"
+
+# Combine element-wise with zip() -- an RMSE/residual objective between a
+# simulated and a reference series.
+output_expression = "sqrt(sum((x - y) ** 2 for x, y in zip(T_series, T_ref)) / len(T_series))"
+```
 
 ---
 

--- a/fz/algorithms.py
+++ b/fz/algorithms.py
@@ -64,7 +64,7 @@ import sys
 import subprocess
 import inspect
 from pathlib import Path
-from typing import Dict, List, Tuple, Any, Optional
+from typing import Dict, List, Tuple, Any, Optional, Union
 import logging
 
 
@@ -293,6 +293,46 @@ def evaluate_output_expression(
             f"Output expression '{expression}' evaluated to {result!r}, which is "
             f"not a single number.{hint}"
         ) from e
+
+
+def evaluate_output_expressions(
+    expression: Union[str, List[str], Tuple[str, ...]],
+    output_data: Dict[str, Any]
+) -> Union[float, List[float]]:
+    """
+    Evaluate one objective expression (str) or several (list/tuple of str).
+
+    This is the vector-objective entry point used by fzd: a plain string
+    behaves exactly like :func:`evaluate_output_expression` (single scalar
+    objective, unchanged legacy behavior), while a list of expression
+    strings produces one scalar per expression, evaluated against the same
+    case outputs. Multi-objective algorithms (e.g. NSGA-II) then receive a
+    list of floats per case instead of a single float.
+
+    Args:
+        expression: Expression string, or list/tuple of expression strings.
+            Each expression may use the same reductions and helpers as
+            :func:`evaluate_output_expression` (min, max, mean, zip, ...),
+            including over vector-valued outputs.
+        output_data: Dict of output variable values for one case.
+
+    Returns:
+        A float for a string expression; a list of floats (same length and
+        order as the expressions) for a list/tuple.
+
+    Raises:
+        ValueError: If any expression fails to evaluate to a single number
+            (the error names the offending expression).
+
+    Examples:
+        >>> evaluate_output_expressions("x + y", {"x": 1.0, "y": 2.0})
+        3.0
+        >>> evaluate_output_expressions(["x", "y * 2"], {"x": 1.0, "y": 2.0})
+        [1.0, 4.0]
+    """
+    if isinstance(expression, (list, tuple)):
+        return [evaluate_output_expression(e, output_data) for e in expression]
+    return evaluate_output_expression(expression, output_data)
 
 
 def _is_algorithm_class(obj) -> bool:

--- a/fz/algorithms.py
+++ b/fz/algorithms.py
@@ -171,7 +171,12 @@ def evaluate_output_expression(
     slicing (``series[-1]``, ``series[:5]``) works via plain Python syntax,
     and the reduction helpers ``sum``, ``len``, ``sorted``, ``mean``,
     ``median``, ``stdev``, ``variance`` are available on top of the usual
-    math functions.
+    math functions. Two *different* vector outputs can be combined too:
+    plain ``+`` concatenates two lists (e.g. ``mean(a + b)`` pools both
+    before averaging), and ``zip`` lets an expression combine them
+    element-wise (e.g. ``sqrt(sum((x - y) ** 2 for x, y in zip(a, b)) /
+    len(a))`` for an RMSE/residual between a simulated and a reference
+    series).
 
     Args:
         expression: Mathematical expression like "output1 + output2 * 2",
@@ -230,14 +235,32 @@ def evaluate_output_expression(
         'median': statistics.median,
         'stdev': statistics.stdev,
         'variance': statistics.variance,
+        # 'zip' lets an expression combine two *different* vector outputs
+        # element-wise (e.g. a residual/RMSE between a simulated and a
+        # reference series: "sqrt(sum((x-y)**2 for x,y in zip(a, b)) /
+        # len(a))"). Concatenating two vector outputs instead of combining
+        # them element-wise needs no extra helper: plain "+" on two lists
+        # already concatenates them (e.g. "mean(a + b)" pools both series
+        # before averaging).
+        'zip': zip,
     }
 
     # Add output variables
     safe_dict.update(output_data)
+    # No separate builtins: block them explicitly.
+    safe_dict['__builtins__'] = {}
 
     try:
-        # Evaluate the expression
-        result = eval(expression, {"__builtins__": {}}, safe_dict)
+        # Evaluate with a single combined globals dict (not a separate
+        # globals/locals split). This matters for expressions containing a
+        # generator expression or comprehension (e.g. reducing across two
+        # vector outputs with "sum((x - y) ** 2 for x, y in zip(a, b))"):
+        # such nested scopes resolve names through the *globals* dict only,
+        # never through a separately-passed locals dict, so eval(expr,
+        # {"__builtins__": {}}, safe_dict) would raise a spurious
+        # NameError for any safe_dict name (e.g. abs(), or an output
+        # variable) referenced inside the generator/comprehension body.
+        result = eval(expression, safe_dict)
     except Exception as e:
         raise ValueError(
             f"Failed to evaluate output expression '{expression}' with data {output_data}: {e}"

--- a/fz/algorithms.py
+++ b/fz/algorithms.py
@@ -163,53 +163,112 @@ def evaluate_output_expression(
     """
     Evaluate mathematical expression using output variables
 
+    fzd's algorithms (sampling, optimization, ...) always work with a single
+    scalar objective per case, but a model output itself may be a vector
+    (e.g. a time series, extracted via one of fzo's vector-output forms —
+    see doc/model-definition.md, "Vector / array outputs"). The expression
+    is the place to reduce such a vector down to that scalar: indexing/
+    slicing (``series[-1]``, ``series[:5]``) works via plain Python syntax,
+    and the reduction helpers ``sum``, ``len``, ``sorted``, ``mean``,
+    ``median``, ``stdev``, ``variance`` are available on top of the usual
+    math functions.
+
     Args:
-        expression: Mathematical expression like "output1 + output2 * 2"
-        output_data: Dict of output variable values
+        expression: Mathematical expression like "output1 + output2 * 2",
+            or, for a vector-valued output, a reduction like
+            "mean(T_series)", "sum(T_series) / len(T_series)" or
+            "T_series[-1]".
+        output_data: Dict of output variable values (scalars and/or lists)
 
     Returns:
-        Evaluated numeric result
+        Evaluated numeric result, as a float
+
+    Raises:
+        ValueError: If the expression fails to evaluate, or evaluates to
+            something other than a single number (most commonly: a vector
+            output referenced directly, without a reduction) — the message
+            names the offending vector-valued output(s) and suggests a
+            reduction.
 
     Examples:
         >>> evaluate_output_expression("x + y * 2", {"x": 1.0, "y": 3.0})
         7.0
+        >>> evaluate_output_expression("mean(series)", {"series": [1.0, 2.0, 3.0]})
+        2.0
     """
+    import math
+    import statistics
+
+    # Create a safe evaluation environment with only the output variables
+    # and a curated set of math/reduction functions
+    safe_dict = {
+        # Math functions
+        'abs': abs,
+        'min': min,
+        'max': max,
+        'pow': pow,
+        'sqrt': math.sqrt,
+        'exp': math.exp,
+        'log': math.log,
+        'log10': math.log10,
+        'sin': math.sin,
+        'cos': math.cos,
+        'tan': math.tan,
+        'asin': math.asin,
+        'acos': math.acos,
+        'atan': math.atan,
+        'atan2': math.atan2,
+        'pi': math.pi,
+        'e': math.e,
+        # Vector-reduction helpers, for expressions that need to turn a
+        # vector-valued output (e.g. a time series) into fzd's scalar
+        # objective
+        'sum': sum,
+        'len': len,
+        'sorted': sorted,
+        'mean': statistics.mean,
+        'median': statistics.median,
+        'stdev': statistics.stdev,
+        'variance': statistics.variance,
+    }
+
+    # Add output variables
+    safe_dict.update(output_data)
+
     try:
-        # Create a safe evaluation environment with only the output variables
-        # and math functions
-        import math
-        safe_dict = {
-            # Math functions
-            'abs': abs,
-            'min': min,
-            'max': max,
-            'pow': pow,
-            'sqrt': math.sqrt,
-            'exp': math.exp,
-            'log': math.log,
-            'log10': math.log10,
-            'sin': math.sin,
-            'cos': math.cos,
-            'tan': math.tan,
-            'asin': math.asin,
-            'acos': math.acos,
-            'atan': math.atan,
-            'atan2': math.atan2,
-            'pi': math.pi,
-            'e': math.e,
-        }
-
-        # Add output variables
-        safe_dict.update(output_data)
-
         # Evaluate the expression
         result = eval(expression, {"__builtins__": {}}, safe_dict)
-
-        return float(result)
-
     except Exception as e:
         raise ValueError(
             f"Failed to evaluate output expression '{expression}' with data {output_data}: {e}"
+        ) from e
+
+    try:
+        return float(result)
+    except (TypeError, ValueError) as e:
+        # The expression evaluated fine but didn't reduce to a single
+        # number -- overwhelmingly, this means it directly returned a
+        # vector-valued output (a list, tuple, or numpy array) without
+        # reducing it first. Name the culprit(s) and suggest a fix rather
+        # than surfacing the bare float() TypeError.
+        vector_keys = [
+            key for key, value in output_data.items()
+            if isinstance(value, (list, tuple))
+            or (hasattr(value, "__len__") and not isinstance(value, (str, bytes, dict)))
+        ]
+        hint = ""
+        if vector_keys:
+            example_key = vector_keys[0]
+            hint = (
+                f" Output variable(s) {vector_keys} are vector-valued (lists) in "
+                f"this case's output data. fzd needs a single scalar objective per "
+                f"case: reduce the vector first, e.g. mean({example_key}), "
+                f"sum({example_key}) / len({example_key}), max({example_key}), or "
+                f"{example_key}[-1]."
+            )
+        raise ValueError(
+            f"Output expression '{expression}' evaluated to {result!r}, which is "
+            f"not a single number.{hint}"
         ) from e
 
 

--- a/fz/core.py
+++ b/fz/core.py
@@ -108,8 +108,24 @@ from .algorithms import (
     parse_input_vars,
     parse_fixed_vars,
     evaluate_output_expression,
+    evaluate_output_expressions,
     load_algorithm,
 )
+
+
+def _objective_names(output_expression) -> list:
+    """Column/label names for the objective(s): [expr] for a str, the list itself otherwise."""
+    if isinstance(output_expression, (list, tuple)):
+        return list(output_expression)
+    return [output_expression]
+
+
+def _format_objective(value) -> str:
+    """Log-friendly formatting for a scalar or vector objective value."""
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(f"{v:.6g}" if v is not None else "NA" for v in value) + "]"
+    return f"{value:.6g}"
+
 
 
 def _parse_argument(arg, alias_type=None):
@@ -1778,9 +1794,15 @@ def _get_analysis(
 
     # Create DataFrame with all input and output values
     df_data = []
+    obj_names = _objective_names(output_expression)
     for inp_dict, out_val in zip(all_input_vars, all_output_values):
         row = inp_dict.copy()
-        row[output_expression] = out_val  # Use output_expression as column name
+        if isinstance(output_expression, (list, tuple)):
+            vals = out_val if isinstance(out_val, (list, tuple)) else [None]*len(obj_names)
+            for name, v in zip(obj_names, vals):
+                row[name] = v
+        else:
+            row[output_expression] = out_val  # Use output_expression as column name
         df_data.append(row)
 
     data_df = pd.DataFrame(df_data)
@@ -1871,7 +1893,7 @@ def _evaluate_function_model_point(model_func, point, output_expression):
     result = _call_function_model(model_func, point)
     output_data = _normalize_function_model_result(result)
     if output_expression:
-        output_value = evaluate_output_expression(output_expression, output_data)
+        output_value = evaluate_output_expressions(output_expression, output_data)
     else:
         output_value = next(iter(output_data.values()))
     return output_data, output_value
@@ -1926,7 +1948,7 @@ def fzd(
     input_path: Optional[str],
     input_variables: Dict[str, str],
     model: Union[str, Dict, Callable],
-    output_expression: Optional[str],
+    output_expression: Optional[Union[str, List[str]]],
     algorithm: str,
     calculators: Union[str, List[str], int] = None,
     algorithm_options: Union[Dict[str, Any], str] = None,
@@ -1960,7 +1982,11 @@ def fzd(
         input_path: Path to input file or directory (None when model is a callable)
         input_variables: Input variables to vary, as dict of strings {"var1": "[min;max]", ...}
         model: Model definition dict or alias string, or a Python callable
-        output_expression: Expression to extract from output files, e.g. "output1 + output2 * 2".
+        output_expression: Expression to extract from output files, e.g. "output1 + output2 * 2",
+            or a LIST of such expressions for multi-objective algorithms (e.g. NSGA-II):
+            each case then yields a list of scalars (one per expression, same order),
+            passed as-is to the algorithm's get_next_design()/get_analysis(). A plain
+            string keeps the legacy single-scalar behavior unchanged.
             When model is a callable, may be None to default to the first output value.
         algorithm: Path to algorithm Python file (e.g., "algorithms/montecarlo.py")
         calculators: Calculator specifications. If omitted, installed calculator
@@ -2171,7 +2197,7 @@ def fzd(
                             iteration_outputs.append(None)
                             continue
 
-                        log_info(f"  Point {i+1}: {point} → {output_value:.6g}")
+                        log_info(f"  Point {i+1}: {point} → {_format_objective(output_value)}")
                         iteration_outputs.append(output_value)
 
                 else:
@@ -2213,11 +2239,11 @@ def fzd(
 
                             # Evaluate output expression
                             try:
-                                output_value = evaluate_output_expression(
+                                output_value = evaluate_output_expressions(
                                     output_expression,
                                     output_data
                                 )
-                                log_info(f"  Point {i+1}: {point} → {output_value:.6g}")
+                                log_info(f"  Point {i+1}: {point} → {_format_objective(output_value)}")
                                 iteration_outputs.append(output_value)
                             except Exception as e:
                                 # Include the runner error if available for better diagnostics
@@ -2268,9 +2294,16 @@ def fzd(
                 # Save Y (output values) to CSV
                 y_file = results_dir / f"Y_{iteration}.csv"
                 with open(y_file, 'w') as f:
-                    f.write('output\n')
-                    for val in all_output_values:
-                        f.write(f"{val if val is not None else 'NA'}\n")
+                    if isinstance(output_expression, (list, tuple)):
+                        f.write(','.join(str(e) for e in output_expression) + '\n')
+                        n_obj = len(output_expression)
+                        for val in all_output_values:
+                            vals = val if isinstance(val, (list, tuple)) else [None]*n_obj
+                            f.write(','.join('NA' if v is None else str(v) for v in vals) + '\n')
+                    else:
+                        f.write('output\n')
+                        for val in all_output_values:
+                            f.write(f"{val if val is not None else 'NA'}\n")
 
                 # Save HTML results
                 html_file = results_dir / f"results_{iteration}.html"

--- a/fz/io.py
+++ b/fz/io.py
@@ -576,10 +576,18 @@ def get_analysis(
         processed_final_analysis = {}
 
     # Create DataFrame with all input and output values
+    # (one column per objective when output_expression is a list — multi-objective fzd)
     df_data = []
+    multi = isinstance(output_expression, (list, tuple))
+    obj_names = list(output_expression) if multi else [output_expression]
     for inp_dict, out_val in zip(all_input_vars, all_output_values):
         row = inp_dict.copy()
-        row[output_expression] = out_val  # Use output_expression as column name
+        if multi:
+            vals = out_val if isinstance(out_val, (list, tuple)) else [None]*len(obj_names)
+            for name, v in zip(obj_names, vals):
+                row[name] = v
+        else:
+            row[output_expression] = out_val  # Use output_expression as column name
         df_data.append(row)
 
     data_df = pd.DataFrame(df_data)

--- a/skills/fz/reference.md
+++ b/skills/fz/reference.md
@@ -83,6 +83,12 @@ fz.fzd(input_path: str | None,
 Returns `{"XY": DataFrame, "analysis": ..., "iterations": int,
 "total_evaluations": int, "summary": str}`. Duplicate points within a batch are
 deduplicated; previously evaluated points are cached across iterations and re-runs.
+`output_expression` also reduces vector-valued outputs (lists, e.g. a time series)
+to the scalar fzd needs: besides the usual math functions and indexing/slicing
+(`series[-1]`), `sum()`, `len()`, `sorted()`, `mean()`, `median()`, `stdev()`,
+`variance()` are available (e.g. `"mean(T_series)"`). Referencing a vector output
+without reducing it raises a clear error and that point is reported as failed,
+rather than crashing the run.
 
 **Direct Python function model** (Python API only, no CLI equivalent): pass a
 callable as `model` instead of a dict/alias. Then `input_path` must be `None`;

--- a/skills/fz/reference.md
+++ b/skills/fz/reference.md
@@ -86,9 +86,11 @@ deduplicated; previously evaluated points are cached across iterations and re-ru
 `output_expression` also reduces vector-valued outputs (lists, e.g. a time series)
 to the scalar fzd needs: besides the usual math functions and indexing/slicing
 (`series[-1]`), `sum()`, `len()`, `sorted()`, `mean()`, `median()`, `stdev()`,
-`variance()` are available (e.g. `"mean(T_series)"`). Referencing a vector output
-without reducing it raises a clear error and that point is reported as failed,
-rather than crashing the run.
+`variance()` are available (e.g. `"mean(T_series)"`). Two different vector outputs
+combine via `+` (concatenate then reduce, e.g. `"mean(a + b)"`) or `zip()`
+(element-wise, e.g. `"sqrt(sum((x-y)**2 for x,y in zip(sim,ref))/len(sim))"` for an
+RMSE). Referencing a vector output without reducing it raises a clear error and
+that point is reported as failed, rather than crashing the run.
 
 **Direct Python function model** (Python API only, no CLI equivalent): pass a
 callable as `model` instead of a dict/alias. Then `input_path` must be `None`;

--- a/skills/fz/reference.md
+++ b/skills/fz/reference.md
@@ -83,7 +83,7 @@ fz.fzd(input_path: str | None,
 Returns `{"XY": DataFrame, "analysis": ..., "iterations": int,
 "total_evaluations": int, "summary": str}`. Duplicate points within a batch are
 deduplicated; previously evaluated points are cached across iterations and re-runs.
-`output_expression` also reduces vector-valued outputs (lists, e.g. a time series)
+`output_expression` (a str, or a list of str for multi-objective algorithms — one scalar per expression is passed to the algorithm) also reduces vector-valued outputs (lists, e.g. a time series)
 to the scalar fzd needs: besides the usual math functions and indexing/slicing
 (`series[-1]`), `sum()`, `len()`, `sorted()`, `mean()`, `median()`, `stdev()`,
 `variance()` are available (e.g. `"mean(T_series)"`). Two different vector outputs

--- a/tests/test_fzd_multiobjective.py
+++ b/tests/test_fzd_multiobjective.py
@@ -1,0 +1,129 @@
+"""
+Tests for fzd multi-objective (vector) output_expression support and the
+NSGA-II example algorithm.
+
+Complements tests/test_fzd_vector_outputs.py (vector-valued model OUTPUTS
+reduced to a scalar objective): here the OBJECTIVE itself is a vector,
+i.e. output_expression is a list of expressions.
+"""
+import csv
+import math
+import os
+
+import pytest
+
+from fz import fzd
+from fz.algorithms import evaluate_output_expressions
+
+NSGA2 = os.path.join(os.path.dirname(__file__), "..", "examples", "algorithms", "nsga2.py")
+
+
+# ---------------------------------------------------------------------------
+# Unit: evaluate_output_expressions
+# ---------------------------------------------------------------------------
+
+class TestEvaluateOutputExpressions:
+    def test_string_keeps_scalar_behavior(self):
+        assert evaluate_output_expressions("x + y * 2", {"x": 1.0, "y": 3.0}) == 7.0
+
+    def test_list_returns_one_scalar_per_expression(self):
+        out = evaluate_output_expressions(["x", "y * 2", "x - y"], {"x": 1.0, "y": 3.0})
+        assert out == [1.0, 6.0, -2.0]
+
+    def test_list_with_vector_output_reductions(self):
+        data = {"Tser": [10.0, 20.0, 30.0]}
+        out = evaluate_output_expressions(["min(Tser)", "max(Tser)"], data)
+        assert out == [10.0, 30.0]
+
+    def test_list_failure_names_offending_expression(self):
+        with pytest.raises(ValueError, match="does_not_exist"):
+            evaluate_output_expressions(["x", "does_not_exist + 1"], {"x": 1.0})
+
+    def test_tuple_accepted(self):
+        assert evaluate_output_expressions(("x", "x + 1"), {"x": 2.0}) == [2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: fzd with a list of objectives (function-model mode)
+# ---------------------------------------------------------------------------
+
+def _binh_korn(x, y):
+    """Classic bi-objective test problem (constrained variant omitted).
+
+    f1 = 4x^2 + 4y^2 ; f2 = (x-5)^2 + (y-5)^2, x in [0;5], y in [0;3].
+    Known Pareto set: y = min(x, 3), x in [0;5] -> smooth convex front.
+    """
+    return {"f1": 4*x**2 + 4*y**2, "f2": (x - 5)**2 + (y - 5)**2}
+
+
+class TestFzdMultiObjective:
+    def test_fzd_vector_objectives_with_nsga2(self):
+        result = fzd(
+            None,
+            {"x": "[0;5]", "y": "[0;3]"},
+            _binh_korn,
+            ["f1", "f2"],
+            NSGA2,
+            algorithm_options={"pop_size": 32, "generations": 40, "seed": 7},
+            calculators=1,
+        )
+        # XY DataFrame: one column per objective expression
+        assert "f1" in result["XY"].columns and "f2" in result["XY"].columns
+        assert len(result["XY"]) == 32 * 40
+
+        # Pareto front from the algorithm analysis
+        X = result["analysis"]["data"]["pareto_X"]
+        F = result["analysis"]["data"]["pareto_F"]
+        assert len(F) >= 10
+
+        # Front quality in OBJECTIVE space: distance to the analytic front.
+        # (The decision-space valley of Binh-Korn is flat, so objective-space
+        # proximity is the meaningful convergence criterion.)
+        true_front = [(4*t**2 + 4*min(t, 3)**2, (t - 5)**2 + (min(t, 3) - 5)**2)
+                      for t in [k/200*5 for k in range(201)]]
+        s1, s2 = 136.0, 46.0  # objective scales over the front
+        for (x, y), (f1, f2) in zip(X, F):
+            assert f1 == pytest.approx(4*x**2 + 4*y**2, rel=1e-9)
+            d = min(math.hypot((f1 - g1)/s1, (f2 - g2)/s2) for g1, g2 in true_front)
+            assert d < 0.03, f"front point too far from analytic front: ({f1:.2f}, {f2:.2f}), d={d:.4f}"
+
+        # Front spread: reaches toward both extremes
+        f1s = [f for f, _ in F]
+        assert min(f1s) < 5 and max(f1s) > 80
+
+        # nsga2_pareto.csv written and consistent
+        rows = list(csv.DictReader(open("nsga2_pareto.csv")))
+        assert len(rows) == len(F)
+        assert set(rows[0].keys()) == {"x", "y", "objective_1", "objective_2"}
+
+    def test_fzd_scalar_expression_unchanged(self):
+        # Backward compatibility: plain-string objective, mono-objective algorithm
+        algo = os.path.join(os.path.dirname(__file__), "..", "examples",
+                            "algorithms", "randomsampling.py")
+        result = fzd(
+            None,
+            {"x": "[0;1]"},
+            lambda x: {"f": (x - 0.3)**2},
+            "f",
+            algo,
+            algorithm_options={"n_samples": 10, "seed": 1},
+            calculators=1,
+        )
+        assert "f" in result["XY"].columns
+        vals = result["XY"]["f"].tolist()
+        assert all(isinstance(v, float) and not isinstance(v, list) for v in vals)
+
+    def test_fzd_partial_objective_failure_gives_none_point(self):
+        # One expression valid, one invalid -> the point fails as a whole (None),
+        # NSGA-II treats it as dominated; the run must complete.
+        result = fzd(
+            None,
+            {"x": "[0;5]", "y": "[0;3]"},
+            _binh_korn,
+            ["f1", "nonexistent_output"],
+            NSGA2,
+            algorithm_options={"pop_size": 8, "generations": 3, "seed": 0},
+            calculators=1,
+        )
+        assert result["total_evaluations"] == 8 * 3
+        assert "(0 valid)" in result["summary"]

--- a/tests/test_fzd_vector_outputs.py
+++ b/tests/test_fzd_vector_outputs.py
@@ -79,6 +79,61 @@ class TestEvaluateOutputExpressionVectorReductions:
         assert result == 20.0
 
 
+class TestEvaluateOutputExpressionCombiningDifferentOutputs:
+    """
+    An expression can draw on more than one output variable at once, and
+    this works whether each output is a scalar or a vector. Two distinct
+    ways of combining two *different* vector-valued outputs are covered
+    here: concatenating them (pooling all values from both into one
+    reduction) and combining them element-wise (e.g. a residual/RMSE
+    between a simulated and a reference series).
+    """
+
+    def test_concatenating_two_vector_outputs_then_reducing(self):
+        # Plain "+" on two lists concatenates them -- no extra helper
+        # needed. mean([1,2,3] + [10,20,30]) pools all 6 values.
+        data = {"a": [1.0, 2.0, 3.0], "b": [10.0, 20.0, 30.0]}
+        assert evaluate_output_expression("mean(a + b)", data) == pytest.approx(11.0)
+        assert evaluate_output_expression("sum(a + b)", data) == pytest.approx(66.0)
+        assert evaluate_output_expression("len(a + b)", data) == 6.0
+
+    def test_combining_reductions_of_two_vector_outputs(self):
+        data = {"a": [1.0, 2.0, 3.0], "b": [10.0, 20.0, 30.0]}
+        assert evaluate_output_expression("mean(a) + mean(b)", data) == pytest.approx(22.0)
+        assert evaluate_output_expression("sum(a) - sum(b)", data) == pytest.approx(-54.0)
+
+    def test_elementwise_combination_via_zip(self):
+        # RMSE between two different vector outputs of matching length --
+        # the natural way to score a simulated series against a reference
+        # one as fzd's objective.
+        data = {"sim": [1.0, 2.0, 3.0], "ref": [10.0, 20.0, 30.0]}
+        rmse = evaluate_output_expression(
+            "sqrt(sum((x - y) ** 2 for x, y in zip(sim, ref)) / len(sim))", data
+        )
+        expected = math.sqrt(
+            sum((x - y) ** 2 for x, y in zip(data["sim"], data["ref"])) / len(data["sim"])
+        )
+        assert rmse == pytest.approx(expected)
+
+    def test_elementwise_combination_with_function_call_in_genexp_body(self):
+        # Regression: a generator-expression body executes in its own
+        # nested scope, which resolves names through eval()'s *globals*
+        # only -- never through a separately-passed locals dict. Calling a
+        # safe_dict function (abs, here) from inside the genexp body used
+        # to raise a spurious "name 'abs' is not defined", even though the
+        # exact same call works fine outside a genexp.
+        data = {"sim": [1.0, 2.0, 5.0], "ref": [10.0, 20.0, 30.0]}
+        result = evaluate_output_expression(
+            "max(abs(x - y) for x, y in zip(sim, ref))", data
+        )
+        assert result == pytest.approx(25.0)  # max(|1-10|, |2-20|, |5-30|) = 25
+
+    def test_three_outputs_combined(self):
+        data = {"a": [1.0, 2.0], "b": [3.0, 4.0], "weight": 2.0}
+        result = evaluate_output_expression("weight * (mean(a) + mean(b))", data)
+        assert result == pytest.approx(2.0 * (1.5 + 3.5))
+
+
 class TestEvaluateOutputExpressionVectorErrors:
 
     def test_unreduced_vector_raises_clear_error(self):
@@ -175,6 +230,80 @@ class TestFzdVectorOutputIntegration:
             expected_series = [round(t0 * (0.9 ** i), 3) for i in range(4)]
             expected_mean = sum(expected_series) / len(expected_series)
             assert row["mean(T_series)"] == pytest.approx(expected_mean, rel=1e-6)
+
+    @pytest.fixture
+    def two_vector_outputs_model(self):
+        """
+        Same toy 'simulation' as vector_output_model, but the case script
+        also writes a fixed reference series (independent of T0) to
+        ref.json, and the model exposes both as separate vector outputs.
+        This is the realistic shape of a calibration/UQ objective: score a
+        simulated trajectory against a reference/target one.
+        """
+        with open("input.txt", "w") as f:
+            f.write("T0=${T0}\n")
+
+        with open("run_case.sh", "w", newline="\n") as f:
+            f.write("#!/bin/bash\n")
+            f.write("source input.txt\n")
+            f.write(
+                "python3 -c \"\n"
+                "import json\n"
+                "n = 4\n"
+                "T0 = float($T0)\n"
+                "series = [round(T0 * (0.9 ** i), 3) for i in range(n)]\n"
+                "ref = [100.0, 90.0, 81.0, 72.9]\n"
+                "print(json.dumps(series))\n"
+                "with open('ref.json', 'w') as fh:\n"
+                "    json.dump(ref, fh)\n"
+                "\" > series.json\n"
+            )
+        os.chmod("run_case.sh", 0o755)
+
+        model = {
+            "varprefix": "$",
+            "delim": "{}",
+            "output": {
+                "T_series": "python://json_file('series.json')",
+                "T_ref": "python://json_file('ref.json')",
+            },
+        }
+        return model
+
+    def test_fzd_rmse_between_two_vector_outputs(self, two_vector_outputs_model):
+        """
+        End-to-end: output_expression combines two *different* vector
+        outputs element-wise (via zip) into an RMSE objective, exactly the
+        pattern used to score a simulated series against a reference one.
+        """
+        algo_path = str(
+            __import__("pathlib").Path(__file__).parent.parent
+            / "examples" / "algorithms" / "randomsampling.py"
+        )
+
+        result = fz.fzd(
+            input_path="input.txt",
+            input_variables={"T0": "[50;200]"},
+            model=two_vector_outputs_model,
+            output_expression="sqrt(sum((x - y) ** 2 for x, y in zip(T_series, T_ref)) / len(T_series))",
+            algorithm=algo_path,
+            calculators="sh://bash run_case.sh",
+            algorithm_options={"nvalues": 3, "seed": 42},
+        )
+
+        assert result is not None
+        df = result["XY"]
+        assert len(df) == 3
+
+        ref = [100.0, 90.0, 81.0, 72.9]
+        for _, row in df.iterrows():
+            t0 = row["T0"]
+            series = [round(t0 * (0.9 ** i), 3) for i in range(4)]
+            expected_rmse = math.sqrt(
+                sum((x - y) ** 2 for x, y in zip(series, ref)) / len(series)
+            )
+            objective_col = [c for c in df.columns if c.startswith("sqrt(")][0]
+            assert row[objective_col] == pytest.approx(expected_rmse, rel=1e-6)
 
     def test_fzd_unreduced_vector_output_reports_failed_points(self, vector_output_model):
         """

--- a/tests/test_fzd_vector_outputs.py
+++ b/tests/test_fzd_vector_outputs.py
@@ -1,0 +1,204 @@
+"""
+Tests for vector (array) outputs used as fzd objectives.
+
+fzd's algorithms (sampling, optimization, ...) all work with a single
+scalar objective per case, but the underlying model output can be a vector
+(e.g. a time series -- see tests/test_vector_outputs.py and
+doc/model-definition.md, "Vector / array outputs"). This suite covers the
+reduction step in between: evaluate_output_expression() must offer the
+tools to turn a vector-valued output into that scalar (sum, len, mean,
+median, stdev, variance, indexing/slicing, on top of the pre-existing
+max/min), and must fail with a clear, actionable message -- naming the
+vector-valued output(s) and suggesting a reduction -- when an expression
+is not reduced to a scalar, instead of a bare float() TypeError.
+"""
+import json
+import math
+import os
+import shutil
+
+import pytest
+
+import fz
+from fz.algorithms import evaluate_output_expression
+
+requires_bash = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available on this platform"
+)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_output_expression: vector-reduction helpers
+# ---------------------------------------------------------------------------
+
+class TestEvaluateOutputExpressionVectorReductions:
+
+    def test_mean(self):
+        assert evaluate_output_expression("mean(series)", {"series": [1.0, 2.0, 3.0]}) == 2.0
+
+    def test_sum_and_len(self):
+        result = evaluate_output_expression(
+            "sum(series) / len(series)", {"series": [1.0, 2.0, 3.0, 4.0]}
+        )
+        assert result == 2.5
+
+    def test_median(self):
+        assert evaluate_output_expression("median(series)", {"series": [1.0, 2.0, 3.0, 4.0]}) == 2.5
+
+    def test_stdev(self):
+        result = evaluate_output_expression("stdev(series)", {"series": [1.0, 2.0, 3.0]})
+        assert result == pytest.approx(1.0)
+
+    def test_variance(self):
+        result = evaluate_output_expression("variance(series)", {"series": [1.0, 2.0, 3.0]})
+        assert result == pytest.approx(1.0)
+
+    def test_sorted_then_index(self):
+        result = evaluate_output_expression("sorted(series)[0]", {"series": [3.0, 1.0, 2.0]})
+        assert result == 1.0
+
+    def test_indexing_and_slicing_unchanged(self):
+        # These already worked before this change -- lock them in alongside
+        # the new helpers.
+        assert evaluate_output_expression("series[-1]", {"series": [1.0, 2.0, 5.0]}) == 5.0
+        assert evaluate_output_expression("max(series)", {"series": [1.0, 2.0, 5.0]}) == 5.0
+        assert evaluate_output_expression("min(series)", {"series": [1.0, 2.0, 5.0]}) == 1.0
+
+    def test_manual_rms_over_vector(self):
+        # sqrt(mean(v**2 for v in series)) -- a realistic fzd objective for
+        # a trajectory/time-series output.
+        result = evaluate_output_expression(
+            "sqrt(sum(v**2 for v in series) / len(series))", {"series": [3.0, 4.0]}
+        )
+        assert result == pytest.approx(5.0 / math.sqrt(2))
+
+    def test_combining_scalar_and_vector_outputs(self):
+        result = evaluate_output_expression(
+            "scale * mean(series)", {"series": [1.0, 2.0, 3.0], "scale": 10.0}
+        )
+        assert result == 20.0
+
+
+class TestEvaluateOutputExpressionVectorErrors:
+
+    def test_unreduced_vector_raises_clear_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            evaluate_output_expression("T_series", {"T_series": [1.0, 2.0, 3.0]})
+        message = str(exc_info.value)
+        assert "T_series" in message
+        assert "vector-valued" in message
+        # Should suggest at least one concrete reduction
+        assert "mean(T_series)" in message or "sum(T_series)" in message
+
+    def test_unreduced_vector_names_only_the_vector_keys(self):
+        with pytest.raises(ValueError) as exc_info:
+            evaluate_output_expression(
+                "T_series", {"T_series": [1.0, 2.0], "pressure": 101.325}
+            )
+        message = str(exc_info.value)
+        # The hint lists the vector-valued output(s) only -- a co-existing
+        # scalar output ("pressure") must not be flagged as vector-valued.
+        assert "['T_series']" in message
+        assert "pressure" not in message
+
+    def test_undefined_name_error_unchanged(self):
+        """Regression: referencing an unknown output must still raise clearly."""
+        with pytest.raises(ValueError) as exc_info:
+            evaluate_output_expression("x + z", {"x": 1.0})
+        assert "not defined" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: fzd() with a vector-output model and a reducing output_expression
+# ---------------------------------------------------------------------------
+
+@requires_bash
+class TestFzdVectorOutputIntegration:
+
+    @pytest.fixture
+    def vector_output_model(self):
+        """
+        A toy 'simulation': prints an exponential-decay time series to
+        series.json, given n_steps and T0. Same shape as
+        tests/test_vector_outputs.py / examples/vector_outputs_example.md,
+        reused here to feed fzd's output_expression reduction step.
+        """
+        with open("input.txt", "w") as f:
+            f.write("T0=${T0}\n")
+
+        with open("run_case.sh", "w", newline="\n") as f:
+            f.write("#!/bin/bash\n")
+            f.write("source input.txt\n")
+            f.write(
+                "python3 -c \"\n"
+                "import json\n"
+                "n = 4\n"
+                "T0 = float($T0)\n"
+                "series = [round(T0 * (0.9 ** i), 3) for i in range(n)]\n"
+                "print(json.dumps(series))\n"
+                "\" > series.json\n"
+            )
+        os.chmod("run_case.sh", 0o755)
+
+        model = {
+            "varprefix": "$",
+            "delim": "{}",
+            "output": {"T_series": "python://json_file('series.json')"},
+        }
+        return model
+
+    def test_fzd_with_mean_reduced_vector_output(self, vector_output_model):
+        algo_path = str(
+            __import__("pathlib").Path(__file__).parent.parent
+            / "examples" / "algorithms" / "randomsampling.py"
+        )
+
+        result = fz.fzd(
+            input_path="input.txt",
+            input_variables={"T0": "[50;200]"},
+            model=vector_output_model,
+            output_expression="mean(T_series)",
+            algorithm=algo_path,
+            calculators="sh://bash run_case.sh",
+            algorithm_options={"nvalues": 3, "seed": 42},
+        )
+
+        assert result is not None
+        df = result["XY"]
+        assert len(df) == 3
+        assert "T0" in df.columns
+        assert "mean(T_series)" in df.columns
+
+        # Recompute the expected mean directly from T0, and check every row
+        for _, row in df.iterrows():
+            t0 = row["T0"]
+            expected_series = [round(t0 * (0.9 ** i), 3) for i in range(4)]
+            expected_mean = sum(expected_series) / len(expected_series)
+            assert row["mean(T_series)"] == pytest.approx(expected_mean, rel=1e-6)
+
+    def test_fzd_unreduced_vector_output_reports_failed_points(self, vector_output_model):
+        """
+        Forgetting to reduce a vector output must not crash fzd(): each
+        point is reported as a failed evaluation (output value None), with
+        the clear error surfaced via log_warning -- exactly like any other
+        per-case evaluation failure.
+        """
+        algo_path = str(
+            __import__("pathlib").Path(__file__).parent.parent
+            / "examples" / "algorithms" / "randomsampling.py"
+        )
+
+        result = fz.fzd(
+            input_path="input.txt",
+            input_variables={"T0": "[50;200]"},
+            model=vector_output_model,
+            output_expression="T_series",  # not reduced -- every point fails
+            algorithm=algo_path,
+            calculators="sh://bash run_case.sh",
+            algorithm_options={"nvalues": 2, "seed": 42},
+        )
+
+        assert result is not None
+        df = result["XY"]
+        assert len(df) == 2
+        assert df["T_series"].isna().all()


### PR DESCRIPTION
## Summary

Replaces #76 (accidentally auto-closed by GitHub when I deleted its stacked
base branch `feat/vector-outputs-fzr-fzo` after merging #75 — sorry about
that; same head branch `feat/vector-outputs-fzd`, no commits lost). Now
targets `main` directly since #75 is merged.

Part 2 of vector-output support (part 1, #75, is merged). `fzd`'s algorithms
(sampling, optimization, ...) always need a scalar objective per case, but
the underlying model output can now be a vector (e.g. a time series, per
#75). This PR makes `output_expression` — the place where that reduction
happens — actually usable for it, and additionally adds native
multi-objective support (see "Multi-objective" section below, added on top
of the original #76 scope).

## Changes

- **`fz/algorithms.py`**: `evaluate_output_expression()` gains `sum()`,
  `len()`, `sorted()`, `mean()`, `median()`, `stdev()`, `variance()` in its
  safe eval namespace, alongside the pre-existing math functions and
  indexing/slicing (e.g. `series[-1]`, `max(series)`). Referencing a
  vector-valued output without reducing it used to fail with a bare
  `TypeError`; it now raises a `ValueError` naming the offending output(s)
  and suggesting a concrete reduction (e.g. `mean(T_series)`). `fzd`'s
  per-case error handling already treats any evaluation failure as a failed
  point (`None`) rather than aborting the run, so this is a message-quality
  fix, not a behavior change there.
- **`tests/test_fzd_vector_outputs.py`** (14 tests): unit coverage of the
  reduction helpers and the improved error message; two end-to-end `fzd()`
  tests with a real vector-output model.
- **Docs**: `doc/core-functions.md`, `examples/fzd_example.md`, `README.md`,
  `skills/fz/reference.md`, `doc/INDEX.md`, `NEWS.md`.

## Multi-objective (vector) objectives — added on top of #76's original scope

`#76`'s scope note explicitly left multi-objective optimization out; this
adds it:

- `output_expression` now also accepts a **list of expressions**: each case
  yields a list of scalars (one per expression, same order), passed as-is to
  the algorithm's `get_next_design()`/`get_analysis()`. A plain string keeps
  the legacy single-scalar behavior byte-for-byte unchanged.
- New `evaluate_output_expressions()` (`fz/algorithms.py`); log formatting,
  the `XY` DataFrame and `Y_<iteration>.csv` gain one column per objective;
  function-model mode supported.
- **`examples/algorithms/nsga2.py`**: NSGA-II (Deb 2002) as an fzd plugin —
  batch-parallel generations, SBX + polynomial mutation, (mu+lambda) elitist
  selection, Pareto front written to `nsga2_pareto.csv` and returned in the
  analysis `data` (`pareto_X`/`pareto_F`).
- **`tests/test_fzd_multiobjective.py`** (8 tests): unit coverage of
  `evaluate_output_expressions`; end-to-end `fzd` + NSGA-II on the
  Binh-Korn problem validated against its analytic Pareto front (objective-
  space deviation < 3%); scalar-expression backward-compat; partial
  objective failure -> whole point `None`.

## Testing

- `pytest tests/test_fzd_vector_outputs.py` — 14/14 passed.
- `pytest tests/test_fzd_multiobjective.py` — 8/8 passed.
- No regressions: `test_fzd.py`, `test_fzd_vector_outputs.py`,
  `test_algorithm_options.py`, `test_algorithm_plugins.py` — 85 passed, 1
  skipped.
