### PR TITLE
fzd: parallelize Python-function model evaluations when calculators>1

### DIFF
--- a/fz/__init__.py
+++ b/fz/__init__.py
@@ -10,7 +10,7 @@ A Python package for wrapping parametric simulations with support for:
 - Smart caching and retry mechanisms
 """
 
-from .core import fzi, fzc, fzo, fzr, fzl, fzd, check_bash_availability_on_windows
+from .core import fzi, fzc, fzo, fzr, fzl, fzd, check_bash_availability_on_windows, FunctionModelParallelError
 
 # Check bash availability on Windows at import time (non-strict: warn only).
 # fz remains importable and fully usable for shell-free workflows (native
@@ -97,7 +97,7 @@ def list_models(global_list=False):
 
 __version__ = "1.1"
 __all__ = [
-    "fzi", "fzc", "fzo", "fzr", "fzl", "fzd",
+    "fzi", "fzc", "fzo", "fzr", "fzl", "fzd", "FunctionModelParallelError",
     "install", "uninstall", "list_models",
     "install_model", "uninstall_model", "list_installed_models",
     "install_algorithm", "uninstall_algorithm", "list_installed_algorithms",

--- a/fz/core.py
+++ b/fz/core.py
@@ -10,6 +10,7 @@ import logging
 import time
 import uuid
 import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections import defaultdict
 import signal
 import sys
@@ -2027,28 +2028,75 @@ def _evaluate_function_model_point(model_func, point, output_expression):
     return output_data, output_value
 
 
-def _run_function_model_design(model_func, design_points, output_expression, max_workers):
-    """Evaluate design_points against model_func, one at a time, in the calling thread.
+class FunctionModelParallelError(RuntimeError):
+    """Raised by fzd() when a Python-function model raises while being evaluated
+    in parallel (calculators=N>1). Kept as a distinct RuntimeError subclass so
+    fzd's own batch-error handling can re-raise it immediately instead of
+    downgrading it to a per-point failure like it does for other exceptions
+    (see _run_function_model_design and fzd)."""
 
-    Always sequential (a plain loop, like R's lapply), regardless of
-    max_workers: concurrent.futures.ThreadPoolExecutor always dispatches to a
-    *worker* thread, even with max_workers=1 — never the calling thread. That
-    breaks model_func callables that are only safe to call from the thread
-    that created them, such as an R closure bridged in via reticulate, which
-    crashes the host process if invoked from any thread other than the main
-    one. There is no way to distinguish such callables from an ordinary,
-    thread-safe Python function, so we always run sequentially to stay safe
-    for both. max_workers is accepted for API compatibility but currently has
-    no effect on execution.
+
+def _run_function_model_design(model_func, design_points, output_expression, max_workers):
+    """Evaluate design_points against model_func.
+
+    - max_workers <= 1 (the default): purely sequential, one call at a time,
+      in the calling thread — like R's lapply, never via a thread pool. This
+      is the only safe mode for callables that may only be invoked from the
+      thread that created them (e.g. an R closure bridged in via reticulate,
+      which can crash the host process if invoked from any other thread);
+      the fz.R wrapper always forces calculators=1 for exactly this reason.
+      Exceptions raised while evaluating an individual point are captured
+      and reported as a per-point failure (see the returned tuples below),
+      letting the algorithm continue with the remaining, successful points.
+
+    - max_workers > 1: dispatches calls to a concurrent.futures.ThreadPoolExecutor
+      with max_workers worker threads, running evaluations concurrently. Only
+      use this when model_func is an ordinary, thread-safe Python function
+      (never for a callable that isn't safe to invoke from arbitrary
+      threads). Because a thread-safety problem can make otherwise-valid
+      points fail — possibly intermittently — once run concurrently, any
+      exception raised while evaluating a point in this mode is treated as
+      fatal for the whole batch: it is re-raised immediately as a
+      RuntimeError that explicitly calls out parallel execution as the
+      likely cause and suggests retrying with calculators=1, instead of
+      being silently downgraded to a per-point failure as in the sequential
+      case above.
+
+    Returns a list of (output_data, output_value, error) tuples, one per
+    design point, in the same order as design_points (error is None on
+    success).
     """
     def _call(point):
-        try:
-            output_data, output_value = _evaluate_function_model_point(model_func, point, output_expression)
-            return output_data, output_value, None
-        except Exception as e:
-            return None, None, str(e)
+        output_data, output_value = _evaluate_function_model_point(model_func, point, output_expression)
+        return output_data, output_value, None
 
-    return [_call(point) for point in design_points]
+    if max_workers is None or max_workers <= 1:
+        results = []
+        for point in design_points:
+            try:
+                results.append(_call(point))
+            except Exception as e:
+                results.append((None, None, str(e)))
+        return results
+
+    results = [None] * len(design_points)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_index = {executor.submit(_call, point): i for i, point in enumerate(design_points)}
+        for future in as_completed(future_to_index):
+            index = future_to_index[future]
+            try:
+                results[index] = future.result()
+            except Exception as e:
+                point = design_points[index]
+                raise FunctionModelParallelError(
+                    f"Model function raised an error while evaluating point {point} "
+                    f"during parallel execution (calculators={max_workers}): {e}. "
+                    "If this function is not safe to call concurrently from multiple "
+                    "threads (e.g. a callable bridged in from another language runtime, "
+                    "such as an R function via reticulate), retry with calculators=1 to "
+                    "force strictly sequential, single-threaded execution."
+                ) from e
+    return results
 
 
 def _save_function_model_iteration_csv(iteration_result_dir, all_var_names, unique_design, unique_results):
@@ -2098,12 +2146,20 @@ def fzd(
        - output_expression may be None, in which case the value of the first
          key of the function's return value is used (or the return value
          itself if it's a plain scalar)
-       - calculators must be an int (defaults to 1), accepted for API
-         compatibility; function calls are always run sequentially, one at a
-         time in the calling thread — never via a thread pool. This is
-         required for model callables that are only safe to call from that
-         thread (e.g. an R function bridged in via reticulate), which cannot
-         be reliably distinguished from an ordinary thread-safe function
+       - calculators must be a positive int (defaults to 1): the number of
+         design points evaluated concurrently. calculators=1 (the default)
+         calls the function sequentially, one at a time, in the calling
+         thread — never via a thread pool. This is required for model
+         callables that are only safe to call from that thread (e.g. an R
+         function bridged in via reticulate); the fz.R wrapper always forces
+         calculators=1 for this reason. calculators=N>1 dispatches calls to
+         a thread pool of N worker threads, running evaluations
+         concurrently — only use this for an ordinary, thread-safe Python
+         function. If any point raises while evaluated in parallel, fzd
+         aborts and re-raises it immediately as an explicit RuntimeError
+         (rather than silently marking just that point as failed), since a
+         thread-safety issue can otherwise surface as sporadic, hard to
+         diagnose per-point failures
        - analysis_dir behaves as usual, except the per-iteration directory
          only contains a CSV of the function's inputs/outputs (no case dirs)
 
@@ -2121,9 +2177,15 @@ def fzd(
         calculators: Calculator specifications. If omitted, installed calculator
             aliases supporting the model id are auto-discovered (like fzr);
             falls back to ["sh://"] when none are found.
-            When model is a callable, this must be an int (defaults to 1),
-            accepted for API compatibility but currently has no effect:
-            calls always run sequentially (see above).
+            When model is a callable, this must be a positive int (defaults
+            to 1): the number of design points evaluated concurrently. See
+            "Direct Python function model" above — calculators=1 runs
+            strictly sequentially in the calling thread (required for
+            callables not safe to invoke from another thread, e.g. an R
+            function via reticulate); calculators=N>1 runs N points at a
+            time in a thread pool (only for thread-safe Python functions),
+            and re-raises any evaluation error immediately instead of
+            downgrading it to a per-point failure.
         algorithm_options: Algorithm-specific options. Can be:
             - Dict: {"batch_size": 10, "max_iter": 100}
             - JSON string: '{"batch_size": 10, "max_iter": 100}'
@@ -2210,6 +2272,10 @@ def fzd(
             if calculators is None:
                 function_workers = 1
             elif isinstance(calculators, int):
+                if calculators < 1:
+                    raise ValueError(
+                        f"calculators must be a positive int when model is a Python callable, got {calculators}"
+                    )
                 function_workers = calculators
             else:
                 raise TypeError("calculators must be an int (number of parallel calls) when model is a Python callable")
@@ -2403,6 +2469,12 @@ def fzd(
                             log_warning(f"  Point {i+1}: No results")
                             iteration_outputs.append(None)
 
+            except FunctionModelParallelError:
+                # Thread-safety issue in a parallel function-model evaluation:
+                # this is fatal for the whole fzd() run, not a per-point
+                # failure, so propagate it to the caller as an explicit error
+                # instead of silently continuing with all-None outputs.
+                raise
             except Exception as e:
                 log_error(f"  ❌ Error evaluating batch: {e}")
                 # Add all points with None outputs

--- a/tests/test_fzd_function_model_parallel.py
+++ b/tests/test_fzd_function_model_parallel.py
@@ -74,7 +74,7 @@ class TestRunFunctionModelDesignParallel:
         def model_func(x):
             with lock:
                 seen_threads.add(threading.current_thread().ident)
-            time.sleep(0.05)
+            time.sleep(0.1)
             return {"y": x * 2}
 
         design_points = [{"x": i} for i in range(8)]
@@ -83,9 +83,11 @@ class TestRunFunctionModelDesignParallel:
         elapsed = time.time() - start
 
         assert sorted(r[1] for r in results) == [0, 2, 4, 6, 8, 10, 12, 14]
-        # 8 points x 0.05s sequentially would take >=0.4s; with 4 workers
-        # it should comfortably finish in well under that.
-        assert elapsed < 0.35
+        # 8 points x 0.1s sequentially would take >=0.8s (2 batches of 4
+        # workers ideally take ~0.2s); allow generous headroom for slower/
+        # contended CI runners (e.g. macOS GitHub Actions) while still
+        # clearly proving concurrent, not sequential, execution.
+        assert elapsed < 0.6
         # More than one worker thread must actually have been used.
         assert len(seen_threads) > 1
 

--- a/tests/test_fzd_function_model_parallel.py
+++ b/tests/test_fzd_function_model_parallel.py
@@ -1,0 +1,219 @@
+"""
+Tests for parallel evaluation of Python-function models in fz.fzd().
+
+fzd(..., model=<callable>, calculators=N, ...) always defaults to N=1
+(strictly sequential, one call at a time in the calling thread -- required
+for callables that are only safe to invoke from that thread, e.g. an R
+closure bridged in via reticulate; the fz.R wrapper always forces
+calculators=1 for this reason, see fz.R's own tests).
+
+For calculators=N>1, evaluations of an ordinary, thread-safe Python function
+now run concurrently in a thread pool of N workers. If any evaluation
+raises while running in parallel, fzd aborts immediately with an explicit
+RuntimeError (mentioning parallel execution and suggesting calculators=1),
+rather than silently downgrading it to a per-point failure as it does in
+the sequential case.
+"""
+import threading
+import time
+
+import pytest
+
+import fz
+from fz.core import _run_function_model_design
+
+
+# ---------------------------------------------------------------------------
+# _run_function_model_design: unit tests
+# ---------------------------------------------------------------------------
+
+class TestRunFunctionModelDesignSequential:
+
+    def test_sequential_runs_in_calling_thread(self):
+        calling_thread = threading.current_thread().ident
+        seen_threads = []
+
+        def model_func(x):
+            seen_threads.append(threading.current_thread().ident)
+            return {"y": x * 2}
+
+        design_points = [{"x": i} for i in range(4)]
+        results = _run_function_model_design(model_func, design_points, None, 1)
+
+        assert [r[1] for r in results] == [0, 2, 4, 6]
+        assert all(t == calling_thread for t in seen_threads)
+
+    def test_sequential_default_max_workers_none(self):
+        # max_workers=None must behave like max_workers=1 (the "calculators
+        # omitted" case), not raise or silently do something else.
+        results = _run_function_model_design(
+            lambda x: {"y": x + 1}, [{"x": 1}, {"x": 2}], None, None
+        )
+        assert [r[1] for r in results] == [2, 3]
+
+    def test_sequential_per_point_failure_is_tolerated(self):
+        def model_func(x):
+            if x == 1:
+                raise ValueError("boom")
+            return {"y": x}
+
+        design_points = [{"x": 0}, {"x": 1}, {"x": 2}]
+        results = _run_function_model_design(model_func, design_points, None, 1)
+
+        assert results[0][2] is None and results[0][1] == 0
+        assert results[1][2] is not None and "boom" in results[1][2]
+        assert results[2][2] is None and results[2][1] == 2
+
+
+class TestRunFunctionModelDesignParallel:
+
+    def test_parallel_runs_across_multiple_threads(self):
+        seen_threads = set()
+        lock = threading.Lock()
+
+        def model_func(x):
+            with lock:
+                seen_threads.add(threading.current_thread().ident)
+            time.sleep(0.05)
+            return {"y": x * 2}
+
+        design_points = [{"x": i} for i in range(8)]
+        start = time.time()
+        results = _run_function_model_design(model_func, design_points, None, 4)
+        elapsed = time.time() - start
+
+        assert sorted(r[1] for r in results) == [0, 2, 4, 6, 8, 10, 12, 14]
+        # 8 points x 0.05s sequentially would take >=0.4s; with 4 workers
+        # it should comfortably finish in well under that.
+        assert elapsed < 0.35
+        # More than one worker thread must actually have been used.
+        assert len(seen_threads) > 1
+
+    def test_parallel_error_aborts_and_raises_explicit_runtime_error(self):
+        def model_func(x):
+            if x == 3:
+                raise ValueError("not thread safe")
+            return {"y": x}
+
+        design_points = [{"x": i} for i in range(6)]
+
+        with pytest.raises(fz.FunctionModelParallelError) as excinfo:
+            _run_function_model_design(model_func, design_points, None, 3)
+
+        message = str(excinfo.value)
+        assert "parallel" in message.lower()
+        assert "calculators=1" in message
+        assert "not thread safe" in message  # original error is chained/included
+
+    def test_parallel_results_preserve_input_order(self):
+        # Workers complete out of submission order (later points sleep less);
+        # results must still line up with design_points by index.
+        def model_func(x):
+            time.sleep(0.05 if x == 0 else 0.0)
+            return {"y": x}
+
+        design_points = [{"x": i} for i in range(5)]
+        results = _run_function_model_design(model_func, design_points, None, 5)
+        assert [r[1] for r in results] == [0, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# fzd(): end-to-end tests with a Python function model
+# ---------------------------------------------------------------------------
+
+class TestFzdFunctionModelCalculators:
+
+    ALGO_PATH = str(
+        __import__("pathlib").Path(__file__).parent.parent
+        / "examples" / "algorithms" / "randomsampling.py"
+    )
+
+    def test_calculators_defaults_to_one_when_omitted(self):
+        calling_thread = threading.current_thread().ident
+        seen_threads = []
+
+        def model_func(x, y):
+            seen_threads.append(threading.current_thread().ident)
+            return {"z": x + y}
+
+        result = fz.fzd(
+            input_path=None,
+            input_variables={"x": "[0;1]", "y": "[0;1]"},
+            model=model_func,
+            output_expression="z",
+            algorithm=self.ALGO_PATH,
+            algorithm_options={"nvalues": 3, "seed": 42},
+        )
+
+        assert result is not None
+        assert all(t == calling_thread for t in seen_threads)
+
+    def test_calculators_greater_than_one_parallelizes(self):
+        seen_threads = set()
+        lock = threading.Lock()
+
+        def model_func(x, y):
+            with lock:
+                seen_threads.add(threading.current_thread().ident)
+            time.sleep(0.05)
+            return {"z": x + y}
+
+        result = fz.fzd(
+            input_path=None,
+            input_variables={"x": "[0;1]", "y": "[0;1]"},
+            model=model_func,
+            output_expression="z",
+            algorithm=self.ALGO_PATH,
+            calculators=5,
+            algorithm_options={"nvalues": 5, "seed": 42},
+        )
+
+        assert result is not None
+        assert len(seen_threads) > 1
+
+    def test_calculators_zero_or_negative_rejected(self):
+        with pytest.raises(ValueError):
+            fz.fzd(
+                input_path=None,
+                input_variables={"x": "[0;1]"},
+                model=lambda x: {"y": x},
+                output_expression="y",
+                algorithm=self.ALGO_PATH,
+                calculators=0,
+                algorithm_options={"nvalues": 2, "seed": 42},
+            )
+
+    def test_calculators_non_int_rejected(self):
+        with pytest.raises(TypeError):
+            fz.fzd(
+                input_path=None,
+                input_variables={"x": "[0;1]"},
+                model=lambda x: {"y": x},
+                output_expression="y",
+                algorithm=self.ALGO_PATH,
+                calculators="sh://",
+                algorithm_options={"nvalues": 2, "seed": 42},
+            )
+
+    def test_parallel_error_propagates_as_explicit_fzd_error(self):
+        call_count = {"n": 0}
+        lock = threading.Lock()
+
+        def model_func(x, y):
+            with lock:
+                call_count["n"] += 1
+                n = call_count["n"]
+            if n == 2:
+                raise ValueError("simulated crash under concurrency")
+            return {"z": x + y}
+
+        with pytest.raises(fz.FunctionModelParallelError, match="parallel"):
+            fz.fzd(
+                input_path=None,
+                input_variables={"x": "[0;1]", "y": "[0;1]"},
+                model=model_func,
+                output_expression="z",
+                algorithm=self.ALGO_PATH,
+                calculators=4,
+                algorithm_options={"nvalues": 6, "seed": 42},
+            )


### PR DESCRIPTION
## Summary

`fzd(..., model=<callable>, calculators=N)` previously accepted `N` only for API compatibility: evaluations always ran **sequentially**, one call at a time, in the calling thread, regardless of its value. This was deliberate (see `_run_function_model_design`'s original docstring): a Python-side `ThreadPoolExecutor` always dispatches to a *worker* thread — even with `max_workers=1` — which crashes callables that are only safe to invoke from the thread that created them (e.g. an R closure bridged in via `reticulate`).

This PR makes `calculators=N>1` actually parallelize evaluations for an ordinary, thread-safe Python function, while preserving the safe default:

- `calculators=1` (the default): unchanged — strictly sequential, one call at a time, in the calling thread, no thread pool at all.
- `calculators=N>1`: dispatches evaluations to a `concurrent.futures.ThreadPoolExecutor` with `N` worker threads, running them concurrently. **Only use this for a model function that is safe to call from arbitrary threads.**
- If **any** point raises while evaluated in parallel, the whole batch aborts immediately with an explicit `fz.FunctionModelParallelError` (a `RuntimeError` subclass) naming the offending point, the `calculators` value, and suggesting a retry with `calculators=1` — instead of silently downgrading it to a per-point failure like sequential mode does for ordinary model errors. A thread-safety problem can otherwise surface as sporadic, hard-to-diagnose per-point failures, so failing the whole run loudly is safer than continuing with partially-corrupted results.
- `calculators` must now be a **positive** int in function-model mode (raises `ValueError` for `calculators <= 0`).
- `FunctionModelParallelError` is exported from the top-level `fz` package.

## Why

`fzd` is documented/used with `calculators=N` as if it parallelizes function-model evaluations (see e.g. the `BuildingOpt_fz.ipynb` notebook in `yannrichet/OptimHome`), but until now that parameter was silently ignored in that mode. This PR makes the parameter do what users reasonably expect for plain Python functions, without weakening the existing safety guarantee for non-thread-safe callables (still opt-in via `calculators=1`, the default).

## Companion change

`Funz/fz.R` needs a matching update (see companion PR): now that `calculators>1` has a *real* effect on this side, the R wrapper must unconditionally force `calculators=1` when `model` is an R function (R closures bridged in via `reticulate` are not safe to call from a worker thread), instead of merely warning that the parameter had no effect.

## Testing

- Added `tests/test_fzd_function_model_parallel.py`: unit tests for `_run_function_model_design` (sequential-in-calling-thread, parallel-uses-multiple-threads, parallel-error-aborts-with-explicit-error, result-order preserved) plus end-to-end `fzd()` tests (default calculators=1, calculators>1 parallelizes, calculators<=0 rejected, non-int rejected, parallel error propagates as `FunctionModelParallelError`).
- Full existing `fzd` suite still green: `tests/test_fzd.py`, `tests/test_fzd_vector_outputs.py`, `tests/test_fzd_multiobjective.py`, `tests/test_fzd_calculator_discovery.py` (65 passed).