### PR TITLE
Raise default run timeout to 1h, allow per-model override

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Default run timeout raised to 1h, per-model override
+
+- `FZ_RUN_TIMEOUT`'s default changed from 600 seconds (10 minutes) to 3600
+  seconds (1 hour).
+- Models can now set their own `"timeout"` entry (int seconds) to override
+  `FZ_RUN_TIMEOUT` for that model specifically. Setting it to `None`/`null`
+  or `0` disables the timeout entirely for that model. An explicit
+  `timeout=` argument to `fzr()`/`fzc()` still takes precedence over both.
+
 ### `--input_variables` no longer required for variable-free datasets
 
 - `fzc`/`fzr` CLI (standalone and `fz compile`/`fz run`) no longer require

--- a/README.md
+++ b/README.md
@@ -2478,8 +2478,8 @@ export FZ_INTERPRETER=python
 # Linux/macOS example: export FZ_SHELL_PATH=/opt/custom/bin:/usr/local/bin
 export FZ_SHELL_PATH=/usr/local/bin:/usr/bin
 
-# Run timeout in seconds (default: 600 = 10 minutes)
-export FZ_RUN_TIMEOUT=3600
+# Run timeout in seconds (default: 3600 = 1 hour)
+export FZ_RUN_TIMEOUT=1800
 
 # Case directory naming scheme: "path" (var=val,... subdirs, default), "hash"
 # (short content hash, avoids filesystem filename length limits with many
@@ -2539,13 +2539,13 @@ See `doc/shell-path.md` and `examples/shell_path_example.md` for detailed docume
 
 ### Timeout Configuration
 
-FZ provides flexible timeout settings at multiple levels for controlling calculation execution time:
+FZ provides flexible timeout settings for controlling calculation execution time:
 
 #### 1. Environment Variable (Global Default)
 
 ```bash
 # Set default timeout for all calculations (in seconds)
-export FZ_RUN_TIMEOUT=3600  # 1 hour (default: 600 seconds = 10 minutes)
+export FZ_RUN_TIMEOUT=1800  # 30 minutes (default: 3600 seconds = 1 hour)
 ```
 
 #### 2. Model Configuration (Per-Model)
@@ -2554,55 +2554,31 @@ export FZ_RUN_TIMEOUT=3600  # 1 hour (default: 600 seconds = 10 minutes)
 model = {
     "varprefix": "$",
     "output": {"result": "cat output.txt"},
-    "timeout": 1800  # 30 minutes for this model
+    "timeout": 1800  # 30 minutes for this model, regardless of FZ_RUN_TIMEOUT
 }
 
 results = fz.fzr("input.txt", input_variables, model, calculators="sh://calc.sh")
 ```
 
-#### 3. Calculator URI Parameter (Per-Calculator)
+A model `timeout` of `None`/`null` or `0` disables the timeout entirely for that
+model (the calculation may run indefinitely):
 
 ```python
-# Set timeout directly in calculator URI
-calculators = [
-    "sh://bash quick_calc.sh?timeout=300",      # 5 minutes
-    "sh://bash slow_calc.sh?timeout=7200",       # 2 hours
-    "ssh://user@hpc.edu/sbatch job.sh?timeout=86400"  # 24 hours
-]
+model = {"timeout": None, "output": {"result": "cat output.txt"}}
+```
 
-results = fz.fzr("input.txt", input_variables, model, calculators=calculators)
+#### 3. `fzr()`/`fzc()` `timeout=` Argument (Per-Call)
+
+```python
+# Overrides both the model's timeout and FZ_RUN_TIMEOUT for this call only
+results = fz.fzr("input.txt", input_variables, model, calculators="sh://calc.sh", timeout=7200)
 ```
 
 #### Priority Order (highest to lowest)
 
-1. **Calculator URI parameter** (`?timeout=300`)
+1. **`timeout=` argument** passed to `fzr()`/`fzc()`
 2. **Model configuration** (`model["timeout"]`)
-3. **Environment variable** (`FZ_RUN_TIMEOUT`)
-4. **Default** (600 seconds = 10 minutes)
-
-**Example combining multiple levels**:
-
-```python
-import os
-
-# Global default: 1 hour
-os.environ['FZ_RUN_TIMEOUT'] = '3600'
-
-# Model-specific: 30 minutes
-model = {
-    "timeout": 1800,
-    "output": {"result": "cat output.txt"}
-}
-
-# Override for specific calculator: 2 hours
-calculators = [
-    "cache://previous_results",
-    "sh://bash calc.sh?timeout=7200",  # Uses 2 hours (URI overrides)
-    "sh://bash calc.sh"                 # Uses 30 minutes (model timeout)
-]
-
-results = fz.fzr("input.txt", input_variables, model, calculators=calculators)
-```
+3. **Environment variable** (`FZ_RUN_TIMEOUT`, default 3600 seconds = 1 hour)
 
 **Timeout Behavior**:
 - Calculation terminates after timeout expires

--- a/doc/calculators.md
+++ b/doc/calculators.md
@@ -313,7 +313,8 @@ calculators = [
 
 **Environment variables**:
 ```bash
-export FZ_RUN_TIMEOUT=3600    # Timeout in seconds (default: 600 = 10 minutes)
+export FZ_RUN_TIMEOUT=3600    # Timeout in seconds (default: 3600 = 1 hour); a model's own
+                               # "timeout" entry (int, or None/0 to disable) overrides this
 export FZ_SSH_KEEPALIVE=300   # For remote SLURM
 ```
 

--- a/doc/model-definition.md
+++ b/doc/model-definition.md
@@ -309,6 +309,19 @@ Unique identifier for the model, useful for documentation and logging.
 model = {"id": "perfectgas", ...}
 ```
 
+### timeout (optional)
+
+Per-model override of the run timeout, in seconds. Takes precedence over the
+`FZ_RUN_TIMEOUT` config default (3600s = 1h) but is itself overridden by an
+explicit `timeout=` argument passed to `fzr()`/`fzc()`/the CLI. Set it to
+`None`/`null` (or `0`) to disable the timeout entirely for this model (the
+calculation is allowed to run indefinitely).
+
+```python
+model = {"timeout": 7200, ...}   # this model gets 2h instead of the 1h default
+model = {"timeout": None, ...}   # no timeout for this model
+```
+
 ## Complete Examples
 
 ### Example 1: Perfect Gas Model

--- a/fz/config.py
+++ b/fz/config.py
@@ -78,8 +78,8 @@ class Config:
         self.ssh_auto_accept_hostkeys = self._parse_bool_env('FZ_SSH_AUTO_ACCEPT_HOSTKEYS', False)
         self.ssh_keepalive = self._parse_int_env('FZ_SSH_KEEPALIVE', 300)  # 5 minutes default
 
-        # Run timeout configuration (default 600 seconds = 10 minutes)
-        self.run_timeout = self._parse_int_env('FZ_RUN_TIMEOUT', 600)
+        # Run timeout configuration (default 3600 seconds = 1 hour)
+        self.run_timeout = self._parse_int_env('FZ_RUN_TIMEOUT', 3600)
 
         # Shell path configuration (overrides system PATH for binary resolution)
         self.shell_path = os.getenv('FZ_SHELL_PATH', None)

--- a/fz/core.py
+++ b/fz/core.py
@@ -1555,7 +1555,7 @@ def fzr(
                   - 'on_case_complete': Called when a case completes. Args: (case_index, total_cases, var_combo, status, result)
                   - 'on_progress': Called periodically. Args: (completed, total, eta_seconds)
                   - 'on_complete': Called when all cases finish. Args: (total_cases, completed_cases, results)
-        timeout: Timeout in seconds for each calculation (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds for each calculation (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         case_naming: How to name each case's result/temp subdirectory:
                   - "path" (default): "var1=val1,var2=val2,..." - human-readable, but can exceed
                     filesystem filename length limits (~255 chars) with many variables.

--- a/fz/helpers.py
+++ b/fz/helpers.py
@@ -634,7 +634,7 @@ def try_calculators_with_retry(non_cache_calculator_ids: List[str], case_index: 
         start_time: Case start time
         original_cwd: Original working directory
         input_files_list: List of input file names in order
-        timeout: Timeout in seconds (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         static_entries: Pre-resolved input_static entries (see resolve_static_files),
             forwarded to remote calculators for explicit transfer of the relative ones
 
@@ -1423,7 +1423,7 @@ def run_cases_parallel(var_combinations: List[Dict], temp_path: Path, resultsdir
         output_keys: List of output keys
         has_input_variables: Whether input_variables dict is non-empty
         callbacks: Optional dict of callback functions for progress monitoring
-        timeout: Timeout in seconds for each calculation (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds for each calculation (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         case_naming: Case directory naming scheme - "path", "hash", or "index" (see _case_subdir_name)
         static_entries: Pre-resolved input_static entries (see resolve_static_files),
             forwarded to remote calculators (ssh/slurm/funz) so they can explicitly

--- a/fz/runners.py
+++ b/fz/runners.py
@@ -1240,6 +1240,27 @@ def resolve_calculators(
     return result
 
 
+def resolve_timeout(model: Optional[Dict], timeout: Optional[int] = None) -> Optional[int]:
+    """
+    Resolve the effective run timeout in seconds.
+
+    Precedence: explicit `timeout` argument > model's own "timeout" entry >
+    FZ_RUN_TIMEOUT config default. A model "timeout" of None/null or 0 disables
+    the timeout for that model (returns None, meaning no timeout).
+
+    Returns:
+        Timeout in seconds, or None if the timeout is disabled.
+    """
+    if timeout is not None:
+        return timeout
+    if isinstance(model, dict) and "timeout" in model:
+        model_timeout = model["timeout"]
+        if model_timeout is None or model_timeout == 0:
+            return None
+        return int(model_timeout)
+    return get_config().run_timeout
+
+
 def run_calculation(
     working_dir: Path,
     calculator_uri: str,
@@ -1257,7 +1278,8 @@ def run_calculation(
         working_dir: Directory containing input files
         calculator_uri: Calculator URI (e.g., "sh://command", "ssh://host/command", "slurm://partition/script")
         model: Model definition dict
-        timeout: Timeout in seconds (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds (None resolves via the model's "timeout" entry, then
+            FZ_RUN_TIMEOUT from config, default 3600)
         original_input_was_dir: Whether original input was a directory
         input_files_list: List of input file names in order (from .fz_hash)
         static_entries: Pre-resolved input_static entries (see
@@ -1270,9 +1292,8 @@ def run_calculation(
     Returns:
         Dict containing calculation results and status
     """
-    # Use config default if timeout not specified
-    if timeout is None:
-        timeout = get_config().run_timeout
+    # Resolution (explicit arg > model's "timeout" entry > config default) happens
+    # in the per-protocol run_*_calculation functions, since they accept model too.
     base_uri = calculator_uri
 
     # Handle different calculator types
@@ -1560,7 +1581,7 @@ def run_local_calculation(
         working_dir: Directory containing input files
         command: Shell command to execute
         model: Model definition dict
-        timeout: Timeout in seconds (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         original_input_was_dir: Whether original input was a directory
         original_cwd: Original working directory
         input_files_list: List of input file names in order (from .fz_hash)
@@ -1568,9 +1589,8 @@ def run_local_calculation(
     Returns:
         Dict containing calculation results and status
     """
-    # Use config default if timeout not specified
-    if timeout is None:
-        timeout = get_config().run_timeout
+    # Resolve effective timeout: explicit arg > model's "timeout" entry > config default
+    timeout = resolve_timeout(model, timeout)
     # Import here to avoid circular imports
     from .core import fzo, is_interrupted
 
@@ -1662,7 +1682,7 @@ def run_local_calculation(
                         raise KeyboardInterrupt("Process interrupted by user")
 
                     # Check for timeout
-                    if elapsed_time >= timeout:
+                    if timeout is not None and elapsed_time >= timeout:
                         raise subprocess.TimeoutExpired(full_command, timeout)
 
                     # Sleep briefly before next poll
@@ -1819,7 +1839,7 @@ def run_ssh_calculation(
         working_dir: Directory containing input files
         ssh_uri: SSH URI (e.g., "ssh://user:password@host:port/command")
         model: Model definition dict
-        timeout: Timeout in seconds (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         input_files_list: List of input file names in order (from .fz_hash)
         static_entries: Pre-resolved input_static entries, explicitly
             transferred (relative ones only - see transfer_static_files_to_remote_sftp)
@@ -1827,9 +1847,8 @@ def run_ssh_calculation(
     Returns:
         Dict containing calculation results and status
     """
-    # Use config default if timeout not specified
-    if timeout is None:
-        timeout = get_config().run_timeout
+    # Resolve effective timeout: explicit arg > model's "timeout" entry > config default
+    timeout = resolve_timeout(model, timeout)
 
     # Import here to avoid circular imports
     from .core import is_interrupted
@@ -1896,7 +1915,7 @@ def run_ssh_calculation(
             "hostname": host,
             "port": port,
             "username": username,
-            "timeout": min(timeout, 30),  # Connection timeout
+            "timeout": 30 if timeout is None else min(timeout, 30),  # Connection timeout
         }
 
         if password:
@@ -2044,7 +2063,7 @@ def run_slurm_calculation(
         working_dir: Directory containing input files
         slurm_uri: SLURM URI (e.g., "slurm://partition/script" or "slurm://user@host:partition/script")
         model: Model definition dict
-        timeout: Timeout in seconds (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         input_files_list: List of input file names in order (from .fz_hash)
         static_entries: Pre-resolved input_static entries; only used for
             remote SLURM execution (local execution shares the filesystem, so the
@@ -2053,9 +2072,8 @@ def run_slurm_calculation(
     Returns:
         Dict containing calculation results and status
     """
-    # Use config default if timeout not specified
-    if timeout is None:
-        timeout = get_config().run_timeout
+    # Resolve effective timeout: explicit arg > model's "timeout" entry > config default
+    timeout = resolve_timeout(model, timeout)
 
     # Import here to avoid circular imports
     from .core import is_interrupted
@@ -2111,7 +2129,7 @@ def _run_local_slurm_calculation(
     partition: str,
     script: str,
     model: Dict,
-    timeout: int,
+    timeout: Optional[int],
     start_time: datetime,
     env_info: Dict,
     input_files_list: List[str] = None,
@@ -2190,7 +2208,7 @@ def _run_local_slurm_calculation(
                     raise KeyboardInterrupt("SLURM job interrupted by user")
 
                 # Check for timeout
-                if elapsed_time >= timeout:
+                if timeout is not None and elapsed_time >= timeout:
                     raise subprocess.TimeoutExpired(full_command, timeout)
 
                 # Sleep briefly before next poll
@@ -2309,7 +2327,7 @@ def _run_remote_slurm_calculation(
     partition: str,
     script: str,
     model: Dict,
-    timeout: int,
+    timeout: Optional[int],
     start_time: datetime,
     env_info: Dict,
     input_files_list: List[str] = None,
@@ -2379,7 +2397,7 @@ def _run_remote_slurm_calculation(
             "hostname": host,
             "port": port,
             "username": username,
-            "timeout": min(timeout, 30),
+            "timeout": 30 if timeout is None else min(timeout, 30),
         }
 
         if password:
@@ -2566,7 +2584,7 @@ def _execute_remote_slurm_command(
                 raise KeyboardInterrupt("Remote SLURM job interrupted by user")
 
             # Check for timeout
-            if elapsed_time >= timeout:
+            if timeout is not None and elapsed_time >= timeout:
                 log_warning(f"⚠️  Remote SLURM job timeout after {timeout}s")
                 try:
                     channel.send('\x03')
@@ -2792,7 +2810,7 @@ def run_funz_calculation(
         working_dir: Directory containing input files
         funz_uri: Funz URI (e.g., "funz://:<port>/<code>")
         model: Model definition dict
-        timeout: Timeout in seconds (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         input_files_list: List of input file names in order (from .fz_hash)
         static_entries: Pre-resolved input_static entries; relative ones are
             explicitly uploaded (they live outside working_dir - only symlinked there
@@ -2801,9 +2819,8 @@ def run_funz_calculation(
     Returns:
         Dict containing calculation results and status
     """
-    # Use config default if timeout not specified
-    if timeout is None:
-        timeout = get_config().run_timeout
+    # Resolve effective timeout: explicit arg > model's "timeout" entry > config default
+    timeout = resolve_timeout(model, timeout)
     # Import here to avoid circular imports
     from .core import is_interrupted, fzo
 
@@ -2931,7 +2948,7 @@ def run_funz_calculation(
         # Create TCP socket connection to discovered port
         log_debug(f"Creating TCP socket connection to {host}:{tcp_port}")
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        connection_timeout = min(timeout, 30)
+        connection_timeout = 30 if timeout is None else min(timeout, 30)
         sock.settimeout(connection_timeout)
         log_debug(f"Socket timeout set to {connection_timeout}s")
 
@@ -3512,7 +3529,7 @@ def _execute_remote_command(
                 raise KeyboardInterrupt("Remote process interrupted by user")
 
             # Check for timeout
-            if elapsed_time >= timeout:
+            if timeout is not None and elapsed_time >= timeout:
                 log_warning(f"⚠️  Remote command timeout after {timeout}s")
                 try:
                     channel.send('\x03')  # Send Ctrl+C
@@ -3687,7 +3704,7 @@ def run_single_case_calculation(
         working_dir: Directory containing input files
         calculator_uri: Calculator URI to use for this case
         model: Model definition dict
-        timeout: Timeout in seconds (None uses FZ_RUN_TIMEOUT from config, default 600)
+        timeout: Timeout in seconds (None resolves via model["timeout"], then FZ_RUN_TIMEOUT config default, 3600)
         original_input_was_dir: Whether original input was a directory
         original_cwd: Original working directory
         input_files_list: List of input file names in order

--- a/skills/fz/reference.md
+++ b/skills/fz/reference.md
@@ -212,6 +212,7 @@ non-zero on failure, and `fzr` exits 1 when no case reached status `done`. Use
     "delim": "{}",
     "commentline": "#",
     "interpreter": "python",
+    "timeout": 1800,
     "output": {
         "name": "shell command run in each case directory, stdout is the value"
     }
@@ -220,7 +221,9 @@ non-zero on failure, and `fzr` exits 1 when no case reached status `done`. Use
 
 All fields optional except `output` (required to parse results). `id` links the model to
 calculator alias files. Search path for aliases: `./.fz/models/<alias>.json` then
-`~/.fz/models/<alias>.json`.
+`~/.fz/models/<alias>.json`. `timeout` (int seconds, or `null`/`0` to disable) overrides
+`FZ_RUN_TIMEOUT` for this model; an explicit `timeout=` argument to `fzr()`/`fzc()` still
+wins over both.
 
 Static files identical across every case (never templated) are declared via `fzr`'s
 `input_static` argument, not the model — see `fz.fzr` above and `doc/core-functions.md`
@@ -265,6 +268,8 @@ timings, exit status); copies everything back; runs the `output` parsing command
 FZ_LOG_LEVEL                 DEBUG | INFO | WARNING | ERROR
 FZ_MAX_WORKERS               max parallel cases
 FZ_MAX_RETRIES               attempts for failed cases (default 5)
+FZ_RUN_TIMEOUT                per-calculation timeout in seconds (default 3600 = 1h);
+                              a model's own "timeout" entry overrides this
 FZ_SSH_AUTO_ACCEPT_HOSTKEYS  1 to skip interactive host-key prompt (CI; use with care)
 FZ_SSH_KEEPALIVE             SSH keepalive seconds
 FZ_SHELL_PATH                bash location on Windows (MSYS2/Git Bash bin dirs)

--- a/tests/test_run_timeout.py
+++ b/tests/test_run_timeout.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Tests for run timeout resolution: config default, per-model override, and
+explicit argument precedence.
+"""
+
+import pytest
+
+from fz.config import Config, get_config
+from fz.runners import resolve_timeout, run_local_calculation
+
+
+class TestResolveTimeout:
+    """Unit tests for resolve_timeout() precedence rules."""
+
+    def test_default_is_config_run_timeout(self):
+        assert resolve_timeout({}) == get_config().run_timeout
+
+    def test_default_run_timeout_is_one_hour(self, monkeypatch):
+        """FZ_RUN_TIMEOUT's built-in default is 3600s (1h), not the old 600s (10min)."""
+        monkeypatch.delenv("FZ_RUN_TIMEOUT", raising=False)
+        assert Config().run_timeout == 3600
+
+    def test_explicit_argument_wins_over_model(self):
+        model = {"timeout": 1800}
+        assert resolve_timeout(model, timeout=60) == 60
+
+    def test_model_timeout_overrides_config_default(self):
+        model = {"timeout": 120}
+        assert resolve_timeout(model) == 120
+
+    def test_model_timeout_none_disables_timeout(self):
+        model = {"timeout": None}
+        assert resolve_timeout(model) is None
+
+    def test_model_timeout_zero_disables_timeout(self):
+        model = {"timeout": 0}
+        assert resolve_timeout(model) is None
+
+    def test_explicit_argument_wins_even_when_model_disables(self):
+        model = {"timeout": None}
+        assert resolve_timeout(model, timeout=30) == 30
+
+    def test_model_without_timeout_key_uses_config_default(self):
+        model = {"varprefix": "$"}
+        assert resolve_timeout(model) == get_config().run_timeout
+
+    def test_non_dict_model_uses_config_default(self):
+        assert resolve_timeout(None) == get_config().run_timeout
+
+
+class TestRunLocalCalculationTimeoutBehavior:
+    """End-to-end: a small model timeout actually aborts a long-running command."""
+
+    @pytest.fixture
+    def slow_input_dir(self, tmp_path):
+        work = tmp_path / "case_work"
+        work.mkdir()
+        (work / "input.txt").write_text("value = 42\n")
+        (work / ".fz_hash").write_text("abc123 input.txt\n")
+        script = work / "slow.sh"
+        script.write_text("#!/bin/bash\nsleep 5\n")
+        script.chmod(0o755)
+        return work
+
+    def test_model_timeout_triggers_timeout_status(self, slow_input_dir):
+        model = {"output": {"result": "echo 42"}, "timeout": 1}
+        result = run_local_calculation(
+            working_dir=slow_input_dir,
+            command=str(slow_input_dir / "slow.sh"),
+            model=model,
+            timeout=None,  # force resolution through the model's own timeout
+            original_cwd=str(slow_input_dir),
+            input_files_list=["input.txt"],
+        )
+        assert result["status"] == "timeout"
+
+    def test_explicit_timeout_argument_overrides_model_timeout(self, slow_input_dir):
+        """A generous explicit timeout beats a very small model timeout."""
+        model = {"output": {"result": "echo 42"}, "timeout": 1}
+        result = run_local_calculation(
+            working_dir=slow_input_dir,
+            command="echo hi",
+            model=model,
+            timeout=30,
+            original_cwd=str(slow_input_dir),
+            input_files_list=["input.txt"],
+        )
+        assert result["status"] == "done"


### PR DESCRIPTION
FZ_RUN_TIMEOUT's default changes from 600s (10min) to 3600s (1h). Models can now set their own "timeout" entry (int seconds) to override this default; None/null or 0 disables the timeout entirely for that model. An explicit timeout= argument to fzr()/fzc() still takes precedence over both.

# Pull Request

## Description

Brief description of what this PR does.

## Related Issues

Fixes #(issue number)
Relates to #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/modification

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing Performed

### Automated Tests
- [ ] All existing tests pass
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality

### Manual Testing
- [ ] Tested on Linux
- [ ] Tested on macOS
- [ ] Tested on Windows

### Test Coverage
```bash
# Paste relevant test output or coverage report
pytest tests/ -v
```

## Documentation

- [ ] Updated README.md
- [ ] Added/updated docstrings
- [ ] Updated CONTRIBUTING.md (if needed)
- [ ] Updated INTERRUPT_HANDLING.md (if needed)
- [ ] Added examples (if applicable)

## Code Quality

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] No new warnings or linting errors
- [ ] Removed debug code and print statements
- [ ] Updated type hints (if applicable)

## Breaking Changes

If this is a breaking change:
- [ ] Described migration path in description
- [ ] Updated version number appropriately
- [ ] Added deprecation warnings (if applicable)

## Screenshots/Examples

(If applicable, add screenshots or example output)

```python
# Example usage
import fz
# ...
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Any additional information reviewers should know.
